### PR TITLE
chore(apps): migrate media apps to home-operations containers

### DIFF
--- a/kubernetes/main/apps/media/nzbhydra2/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/nzbhydra2/app/helmrelease.yaml
@@ -31,8 +31,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/linuxserver/nzbhydra2
-              tag: 8.0.0
+              repository: ghcr.io/home-operations/nzbhydra2
+              tag: 8.1.2@sha256:bc46a10b2d557e433daf7f39c0918872cad732713fc1e3eb51054e1f24b6fe78
             env:
               NZBHYDRA2__PORT: &port 5076
               NZBHYDRA2__THEME: dark

--- a/kubernetes/main/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/radarr/app/helmrelease.yaml
@@ -36,8 +36,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/linuxserver/radarr
-              tag: 6.0.4
+              repository: ghcr.io/home-operations/radarr
+              tag: 6.1.0.10293@sha256:22bbf7e924dd929b756147d8110664c3e2da37c59516b249945ab1d63657be29
             env:
               RADARR__PORT: &port 7878
               RADARR__THEME: dark

--- a/kubernetes/main/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/sabnzbd/app/helmrelease.yaml
@@ -34,8 +34,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/linuxserver/sabnzbd
-              tag: 4.5.5
+              repository: ghcr.io/home-operations/sabnzbd
+              tag: 4.5.5@sha256:241c557c614ed0ec487206059d88721fb24237333c7b660fdde8848b9f2076ac
             env:
               TZ: America/Toronto
               SABNZBD__PORT: &port 8080


### PR DESCRIPTION
- Migrate radarr, sonarr, sabnzbd, and nzbhydra2 to ghcr.io/home-operations
- Switch to rolling tag with SHA256 digests for reproducibility
- Better k8s integration, non-root containers, improved Renovate support