### PR TITLE
feat(system-upgrade): deploy tuppr for automated Talos and Kubernetes upgrades

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -40,6 +40,21 @@
         commitMessageTopic: "{{{groupName}}} group"
       },
       minimumGroupSize: 2
+    },
+    {
+      description: "Kubernetes Group",
+      groupName: "Kubernetes",
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "/siderolabs\\/kubelet/",
+        "/kube-apiserver/",
+        "/kube-controller-manager/",
+        "/kube-scheduler/"
+      ],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group"
+      },
+      minimumGroupSize: 2
     }
   ]
 }

--- a/kubernetes/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: system-upgrade
+
+components:
+  - ../../components/alerts
+
+resources:
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  # Flux-Kustomizations
+  - ./tuppr/ks.yaml

--- a/kubernetes/apps/system-upgrade/namespace.yaml
+++ b/kubernetes/apps/system-upgrade/namespace.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.34.0/namespace-v1.json
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tuppr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: tuppr
+  interval: 1h
+  values:
+    replicaCount: 2
+    controller:
+      logLevel: info
+    monitoring:
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/apps/system-upgrade/tuppr/app/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tuppr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.5
+  url: oci://ghcr.io/home-operations/charts/tuppr

--- a/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.1.5
+    tag: 0.1.4
   url: oci://ghcr.io/home-operations/charts/tuppr

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr
+spec:
+  targetNamespace: system-upgrade
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/system-upgrade/tuppr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 1h
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tuppr-upgrades
+spec:
+  targetNamespace: system-upgrade
+  dependsOn:
+    - name: tuppr
+  path: ./kubernetes/apps/system-upgrade/tuppr/upgrades
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 1h

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/tuppr.home-operations.com/kubernetesupgrade_v1alpha1.json
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: KubernetesUpgrade
+metadata:
+  name: kubernetes
+spec:
+  kubernetes:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    version: v1.35.0
+  healthChecks:
+    - apiVersion: volsync.backube/v1alpha1
+      kind: ReplicationSource
+      expr: |-
+        status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      expr: |-
+        status.ceph.health in ['HEALTH_OK']

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./kubernetesupgrade.yaml
+  - ./prometheusrule.yaml
+  - ./talosupgrade.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/prometheusrule.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/prometheusrule.yaml
@@ -1,0 +1,87 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: tuppr
+spec:
+  groups:
+    - name: tuppr.talosupgrade
+      rules:
+        - alert: TalosUpgradeNodeFailed
+          expr: tuppr_talos_upgrade_nodes_failed > 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              Talos upgrade {{ $labels.name }} has {{ $value }} failed node(s)
+            description: >-
+              Talos upgrade {{ $labels.name }} has {{ $value }} node(s) that
+              failed to upgrade. The upgrade has stopped and requires manual
+              intervention (fix the underlying issue and reset with the reset
+              annotation).
+        - alert: TalosUpgradeFailed
+          expr: tuppr_talos_upgrade_phase{phase="Failed"} > 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              Talos upgrade {{ $labels.name }} is in Failed phase
+            description: >-
+              Talos upgrade {{ $labels.name }} has entered the Failed phase.
+              Check controller logs and node conditions for details.
+        - alert: TalosUpgradeStuck
+          expr: >-
+            tuppr_talos_upgrade_phase{phase=~"Upgrading|Rebooting|Draining|HealthChecking"} > 0
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              Talos upgrade {{ $labels.name }} stuck in {{ $labels.phase }} phase
+            description: >-
+              Talos upgrade {{ $labels.name }} has been in the
+              {{ $labels.phase }} phase for more than 1h.
+              Check the upgrade job and target node for errors.
+    - name: tuppr.kubernetesupgrade
+      rules:
+        - alert: KubernetesUpgradeFailed
+          expr: tuppr_kubernetes_upgrade_phase{phase="Failed"} > 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              Kubernetes upgrade {{ $labels.name }} is in Failed phase
+            description: >-
+              Kubernetes upgrade {{ $labels.name }} has entered the Failed phase.
+              Check controller logs and the upgrade job for details.
+        - alert: KubernetesUpgradeStuck
+          expr: >-
+            tuppr_kubernetes_upgrade_phase{phase=~"Upgrading|HealthChecking"} > 0
+          for: 45m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              Kubernetes upgrade {{ $labels.name }} stuck in {{ $labels.phase }} phase
+            description: >-
+              Kubernetes upgrade {{ $labels.name }} has been in the
+              {{ $labels.phase }} phase for more than 45 minutes.
+              Check the upgrade job and control-plane nodes for errors.
+    - name: tuppr.jobs
+      rules:
+        - alert: UpgradeJobRunningTooLong
+          expr: tuppr_upgrade_jobs_active > 0
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              {{ $labels.upgrade_type | title }} upgrade job running for over 1 hour
+            description: >-
+              A {{ $labels.upgrade_type }} upgrade job has been active for more
+              than 1 hour, which exceeds the expected duration. The job may be
+              stuck. Check the job logs in the controller namespace.

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/tuppr.home-operations.com/talosupgrade_v1alpha1.json
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: TalosUpgrade
+metadata:
+  name: talos
+spec:
+  talos:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    version: v1.12.5
+  policy:
+    rebootMode: powercycle
+  healthChecks:
+    - apiVersion: volsync.backube/v1alpha1
+      kind: ReplicationSource
+      expr: |-
+        status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      expr: |-
+        status.ceph.health in ['HEALTH_OK']
+  drain:
+    ignoreDaemonSets: true
+    deleteLocalData: true


### PR DESCRIPTION
## Summary

- Deploys [tuppr](https://github.com/home-operations/tuppr) (v0.1.5) as the automated upgrade controller for Talos Linux and Kubernetes
- Splits controller (`app/`) and upgrade resources (`upgrades/`) into separate Flux Kustomizations so the controller is healthy before CRDs are applied
- Adds `TalosUpgrade` (v1.12.5, powercycle reboot) and `KubernetesUpgrade` (v1.35.0) CRDs with health check gates on Ceph (`HEALTH_OK`) and Volsync (not syncing) before each node upgrade proceeds
- Adds PrometheusRule with alerts for failed/stuck Talos and Kubernetes upgrades
- Renovate will track `ghcr.io/siderolabs/installer` and `ghcr.io/siderolabs/kubelet` to open version bump PRs; merging them triggers rolling upgrades automatically

## Notes

- No manual secret management needed — tuppr's helm chart creates a `talos.dev/v1alpha1/ServiceAccount` which Talos provisions into a `tuppr-talosconfig` secret automatically (namespace already whitelisted in `kubernetesTalosAPIAccess`)

## Test plan

- [x] Flux reconciles `system-upgrade` namespace and `tuppr` HelmRelease successfully
- [x] `tuppr-talosconfig` secret is created automatically by Talos in `system-upgrade`
- [x] `TalosUpgrade` and `KubernetesUpgrade` resources reach `Completed` phase (all nodes already at target versions)
- [x] ServiceMonitor is scraped by Prometheus