### PR TITLE
feat(security): add Kanidm identity provider

### DIFF
--- a/kubernetes/apps/security/kanidm/app/backendtlspolicy.yaml
+++ b/kubernetes/apps/security/kanidm/app/backendtlspolicy.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.nerdz.cloud/gateway.networking.k8s.io_backendtlspolicy_v1.json
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: kanidm-backend-tls
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: kanidm
+  validation:
+    wellKnownCACertificates: System
+    hostname: auth.dcunha.io

--- a/kubernetes/apps/security/kanidm/app/externalsecret.yaml
+++ b/kubernetes/apps/security/kanidm/app/externalsecret.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kanidm-tls
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kanidm-tls
+    creationPolicy: Orphan
+    template:
+      type: kubernetes.io/tls
+      metadata:
+        annotations:
+          cert-manager.io/alt-names: "*.dcunha.io,dcunha.io"
+          cert-manager.io/certificate-name: dcunha.io
+          cert-manager.io/common-name: dcunha.io
+          cert-manager.io/issuer-kind: ClusterIssuer
+          cert-manager.io/issuer-name: letsencrypt-production
+        labels:
+          controller.cert-manager.io/fao: "true"
+  dataFrom:
+    - extract:
+        key: dcunha-io-tls
+        decodingStrategy: Base64

--- a/kubernetes/apps/security/kanidm/app/helmrelease.yaml
+++ b/kubernetes/apps/security/kanidm/app/helmrelease.yaml
@@ -1,0 +1,102 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kanidm
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: kanidm
+  interval: 1h
+  values:
+    controllers:
+      kanidm:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/kanidm/server
+              tag: 1.10.0
+            env:
+              KANIDM_DOMAIN: auth.dcunha.io
+              KANIDM_ORIGIN: https://auth.dcunha.io
+              KANIDM_BINDADDRESS: "[::]:8443"
+              KANIDM_DB_PATH: /data/kanidm.db
+              KANIDM_TLS_CHAIN: /certs/tls.crt
+              KANIDM_TLS_KEY: /certs/tls.key
+              KANIDM_LOG_LEVEL: info
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /status
+                    port: 8443
+                    scheme: HTTPS
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /status
+                    port: 8443
+                    scheme: HTTPS
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          https:
+            port: 8443
+            protocol: HTTPS
+    route:
+      app:
+        hostnames:
+          - auth.dcunha.io
+        parentRefs:
+          - name: external-gateway
+            namespace: network
+        rules:
+          - backendRefs:
+              - name: kanidm
+                port: 8443
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /data
+      certs:
+        type: secret
+        name: kanidm-tls
+        defaultMode: 0400
+        globalMounts:
+          - path: /certs
+      run:
+        type: emptyDir
+        globalMounts:
+          - path: /var/run

--- a/kubernetes/apps/security/kanidm/app/kustomization.yaml
+++ b/kubernetes/apps/security/kanidm/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./backendtlspolicy.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/security/kanidm/app/ocirepository.yaml
+++ b/kubernetes/apps/security/kanidm/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kanidm
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/security/kanidm/ks.yaml
+++ b/kubernetes/apps/security/kanidm/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kanidm
+spec:
+  components:
+    - ../../../../components/volsync
+  targetNamespace: security
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: external-secrets
+      namespace: external-secrets
+  path: ./kubernetes/apps/security/kanidm/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 1h
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SCHEDULE: "0 * * * *"

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: security
+
+components:
+  - ../../components/alerts
+
+resources:
+  - ./namespace.yaml
+  - ./kanidm/ks.yaml

--- a/kubernetes/apps/security/namespace.yaml
+++ b/kubernetes/apps/security/namespace.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.34.0/namespace-v1.json
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary

- Deploys Kanidm 1.10.0 as a centralised OIDC/SSO provider in a new `security` namespace
- Uses the existing wildcard `*.dcunha.io` Let's Encrypt cert via ExternalSecret from 1Password — no new cert issuance
- BackendTLSPolicy required since Kanidm mandates TLS on the backend connection (cannot run plain HTTP)
- VolSync hourly backups of the SQLite database to TrueNAS via Kopia
- app-template 5.0.0 (matches upstream)

## Notes

Post-deploy bootstrap required (one-time):
```bash
kubectl exec -n security -it deployment/kanidm -- kanidmd recover-account admin
kubectl exec -n security -it deployment/kanidm -- kanidmd recover-account idm_admin