### PR TITLE
feat(grafana): add Kanidm OIDC authentication

### DIFF
--- a/kubernetes/apps/observability/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/app/externalsecret.yaml
@@ -13,6 +13,7 @@ spec:
     template:
       data:
         GF_SECURITY_ADMIN_PASSWORD: "{{ .GF_SECURITY_ADMIN_PASSWORD }}"
+        GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "{{ .GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET }}"
   dataFrom:
     - extract:
         key: grafana

--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -17,6 +17,22 @@ spec:
       disable_login_form: "false"
     auth.anonymous:
       enabled: "true"
+    auth.generic_oauth:
+      enabled: "true"
+      name: Kanidm
+      client_id: grafana
+      client_secret: $__env{GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET}
+      scopes: openid,profile,email,groups
+      auth_url: https://auth.dcunha.io/ui/oauth2
+      token_url: https://auth.dcunha.io/oauth2/token
+      api_url: https://auth.dcunha.io/oauth2/openid/grafana/userinfo
+      use_pkce: "true"
+      use_refresh_token: "true"
+      allow_sign_up: "true"
+      login_attribute_path: preferred_username
+      email_attribute_path: email
+      groups_attribute_path: groups
+      role_attribute_path: "contains(grafana_role[*], 'Admin') && 'Admin' || 'Viewer'"
     log:
       mode: console
     metrics:
@@ -44,6 +60,11 @@ spec:
                     secretKeyRef:
                       name: grafana-admin-password
                       key: GF_SECURITY_ADMIN_PASSWORD
+                - name: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-password
+                      key: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true


### PR DESCRIPTION
Wires Grafana to Kanidm as an OIDC provider via auth.generic_oauth. Client secret pulled from 1Password via the existing grafana ExternalSecret. Local admin login remains enabled alongside SSO.