### PR TITLE
feat(bookboss): add Kanidm OIDC authentication

### DIFF
--- a/kubernetes/apps/default/bookboss/app/externalsecret.yaml
+++ b/kubernetes/apps/default/bookboss/app/externalsecret.yaml
@@ -15,6 +15,7 @@ spec:
       data:
         BOOKBOSS__ENCRYPTION_SECRET: "{{ .ENCRYPTION_SECRET }}"
         BOOKBOSS__METADATA__HARDCOVER_API_TOKEN: "{{ .HARDCOVER_API_TOKEN }}"
+        BOOKBOSS__OIDC__CLIENT_SECRET: "{{ .BOOKBOSS__OIDC__CLIENT_SECRET }}"
   dataFrom:
     - extract:
         key: bookboss

--- a/kubernetes/apps/default/bookboss/app/helmrelease.yaml
+++ b/kubernetes/apps/default/bookboss/app/helmrelease.yaml
@@ -27,6 +27,8 @@ spec:
               BOOKBOSS__IMPORT__BOOKDROP_PATH: /media/book-ingest
               BOOKBOSS__IMPORT__POLL_INTERVAL_SECS: 60
               BOOKBOSS__IMPORT__WORKER_POLL_INTERVAL_SECS: 5
+              BOOKBOSS__OIDC__DISCOVERY_URL: "https://auth.dcunha.io/oauth2/openid/bookboss"
+              BOOKBOSS__OIDC__CLIENT_ID: bookboss
             envFrom:
               - secretRef:
                   name: bookboss


### PR DESCRIPTION
Configure BookBoss OIDC via Kanidm with discovery URL and client ID as env vars; inject client secret from 1Password via ExternalSecret.