### PR TITLE
fix(observability): resolve firing alerts from scrape config mismatches

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -62,6 +62,13 @@ spec:
             - matchExpressions:
                 - key: node-role.kubernetes.io/control-plane
                   operator: Exists
+    prometheus:
+      service:
+        enabled: false
+      monitor:
+        enabled: false
+    prometheusRules:
+      enabled: false
     tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/kubernetes/apps/observability/silence-operator/silences/silences.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/silences.yaml
@@ -24,6 +24,20 @@ spec:
   targetTags: []
 
 ---
+# pantheon (Proxmox host) consistently runs at ~94% — hardware limit, not an actionable alert
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: pantheon-memory-high
+spec:
+  matchers:
+    - name: alertname
+      value: NodeMemoryHighUtilization
+    - name: instance
+      value: pantheon
+  targetTags: []
+
+---
 # Talos mounts /etc/nfsmount.conf as a bind mount — not a real filesystem
 apiVersion: monitoring.giantswarm.io/v1alpha1
 kind: Silence

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -82,6 +82,17 @@ spec:
               tlsConfig:
                 insecureSkipVerify: true
 
+    # Rename job from "core-dns" (component label) to "coredns" to match alert expressions
+    coreDns:
+      vmScrape:
+        spec:
+          endpoints:
+            - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+              port: http-metrics
+              relabelConfigs:
+                - targetLabel: job
+                  replacement: coredns
+
     # Cilium replaces kube-proxy
     kubeProxy:
       enabled: false

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
       cephFSKernelMountOptions: ms_mode=prefer-crc
       enableLiveness: true
       serviceMonitor:
-        enabled: true
+        enabled: false
     image:
       repository: ghcr.io/rook/ceph
     monitoring:


### PR DESCRIPTION
## Summary

- **CoreDNS**: Disabled coredns chart's built-in prometheus service/monitor/rules (selectors didn't match the actual `kube-dns` service); added relabelConfig in victoria-metrics to rename the scraped job from `core-dns` → `coredns` so `CoreDNSDown` alert expression matches
- **CSI metrics**: Disabled rook-ceph CSI serviceMonitor — no `csi-metrics` service exists, causing `ScrapePoolHasNoTargets`
- **Pantheon memory**: Added silence for `NodeMemoryHighUtilization` on `pantheon` — Proxmox host consistently runs at ~94% RAM (hardware ceiling, not actionable)
- Also deleted orphaned VMServiceScrapes/VMRules (zigbee2mqtt, frigate, coredns, csi-metrics) that were auto-converted from ServiceMonitors but had no valid targets; these are not in git so no file changes needed

## Test plan

- [x] Applied live with `just kube apply-ks` for all affected namespaces
- [x] `flux reconcile helmrelease` confirmed upgrades applied cleanly
- [x] vmsingle query confirms CoreDNS scraped as `job="coredns"` with all 3 pods UP
- [x] Firing alert count reduced from ~24 → 2 actionable (NodeMemoryHighUtilization silenced, CPUThrottlingHigh/vmagent severity=info resolving as 15m window rolls over)
- [x] Watchdog still routing correctly to heartbeat receiver