### PR TITLE
feat(default): add immich photo management

### DIFF
--- a/kubernetes/apps/default/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/default/immich/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &secretname immich
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *secretname
+    template:
+      engineVersion: v2
+      data:
+        DB_PASSWORD: "{{ .DB_PASSWORD }}"
+        POSTGRES_PASSWORD: "{{ .DB_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: immich

--- a/kubernetes/apps/default/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/helmrelease.yaml
@@ -1,0 +1,232 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: immich
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: immich
+  interval: 1h
+  values:
+    controllers:
+      server:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+        containers:
+          app:
+            image:
+              repository: ghcr.io/immich-app/immich-server
+              tag: v2.7.5
+            env:
+              TZ: America/Toronto
+              DB_HOSTNAME: immich-postgres.default.svc.cluster.local
+              DB_USERNAME: immich
+              DB_DATABASE_NAME: immich
+              REDIS_HOSTNAME: immich-redis.default.svc.cluster.local
+              IMMICH_MACHINE_LEARNING_URL: http://immich-machine-learning.default.svc.cluster.local:3003
+            envFrom:
+              - secretRef:
+                  name: immich
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/server/ping
+                    port: 2283
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/server/ping
+                    port: 2283
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+
+      machine-learning:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+        containers:
+          app:
+            image:
+              repository: ghcr.io/immich-app/immich-machine-learning
+              tag: v2.7.5
+            env:
+              TZ: America/Toronto
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1Gi
+              limits:
+                memory: 4Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+
+      postgres:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+            fsGroup: 999
+            fsGroupChangePolicy: OnRootMismatch
+        statefulset:
+          volumeClaimTemplates:
+            - name: data
+              storageClass: ceph-block
+              accessMode: ReadWriteOnce
+              size: 20Gi
+              globalMounts:
+                - path: /var/lib/postgresql/data
+                  subPath: pgdata
+        containers:
+          app:
+            image:
+              repository: ghcr.io/immich-app/postgres
+              tag: 14-vectorchord0.4.3-pgvectors0.2.0
+            env:
+              POSTGRES_USER: immich
+              POSTGRES_DB: immich
+              PGDATA: /var/lib/postgresql/data/pgdata
+            envFrom:
+              - secretRef:
+                  name: immich
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+
+      redis:
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+        containers:
+          app:
+            image:
+              repository: docker.io/valkey/valkey
+              tag: 8-alpine
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+
+    service:
+      server:
+        controller: server
+        ports:
+          http:
+            port: 2283
+      machine-learning:
+        controller: machine-learning
+        ports:
+          http:
+            port: 3003
+      postgres:
+        controller: postgres
+        ports:
+          postgres:
+            port: 5432
+      redis:
+        controller: redis
+        ports:
+          redis:
+            port: 6379
+
+    route:
+      app:
+        hostnames:
+          - photos.dcunha.io
+        parentRefs:
+          - name: external-gateway
+            namespace: network
+          - name: internal-gateway
+            namespace: network
+        rules:
+          - backendRefs:
+              - name: immich-server
+                port: 2283
+
+    persistence:
+      library:
+        type: nfs
+        server: 10.10.99.100
+        path: /mnt/atlas/media/photos
+        advancedMounts:
+          server:
+            app:
+              - path: /usr/src/app/upload
+      model-cache:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 20Gi
+        storageClass: ceph-block
+        advancedMounts:
+          machine-learning:
+            app:
+              - path: /cache
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          server:
+            app:
+              - path: /tmp
+          machine-learning:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/default/immich/app/kustomization.yaml
+++ b/kubernetes/apps/default/immich/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./trafficpolicy.yaml

--- a/kubernetes/apps/default/immich/app/ocirepository.yaml
+++ b/kubernetes/apps/default/immich/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: immich
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/immich/app/trafficpolicy.yaml
+++ b/kubernetes/apps/default/immich/app/trafficpolicy.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/backendtrafficpolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: immich
+spec:
+  connection:
+    bufferLimit: 1Gi
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: immich

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app immich
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/default/immich/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 1h

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -10,4 +10,5 @@ components:
 resources:
   - ./namespace.yaml
   - ./bookboss/ks.yaml
+  - ./immich/ks.yaml
   - ./komga/ks.yaml

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -149,7 +149,7 @@ spec:
       trustedCIDRs:
         - 10.42.0.0/16
   connection:
-    bufferLimit: 8Mi
+    bufferLimit: 1Gi
     maxAcceptPerSocketEvent: 0
   http2:
     initialStreamWindowSize: 2Mi


### PR DESCRIPTION
## Summary
- Deploy Immich photo management stack (server, machine-learning, postgres StatefulSet, redis/valkey) in the `default` namespace
- Photo library on TrueNAS NFS (`/mnt/atlas/media/photos`), postgres on ceph-block via StatefulSet volumeClaimTemplate, ML model cache on inline ceph-block PVC
- Route on `photos.dcunha.io` via both internal and external gateways
- Secrets via 1Password ExternalSecret (`immich` item, `DB_PASSWORD` field)
- Raise Envoy `ClientTrafficPolicy` buffer limit from 8Mi → 1Gi to support photo/video uploads; add Immich-specific `BackendTrafficPolicy` (1Gi) targeting the HTTPRoute

## Test plan
- [x] All four pods running (server, machine-learning, postgres, redis)
- [x] DB migrations ran on fresh postgres
- [x] `https://photos.dcunha.io` reachable via internal and external gateway
- [x] Photo upload succeeds (post buffer limit fix)
- [ ] Kanidm OAuth wired up (admin UI step, post-merge)