### PR TITLE
chore(home-automation): inject Pocket-ID client secret into Home Assistant

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/externalsecret.yaml
@@ -22,6 +22,7 @@ spec:
         HASS_LATITUDE: "{{ .LATITUDE }}"
         HASS_LONGITUDE: "{{ .LONGITUDE }}"
         HASS_PIRATE_WEATHER_API_KEY: "{{ .PIRATE_WEATHER_API_KEY }}"
+        POCKET_ID_CLIENT_SECRET: "{{ .POCKET_ID_CLIENT_SECRET }}"
   dataFrom:
     - extract:
         key: home-assistant


### PR DESCRIPTION
## Summary
- Add `POCKET_ID_CLIENT_SECRET` to the Home Assistant ExternalSecret, pulled from 1Password

## Test plan
- [x] Secret synced and present in pod env