### PR TITLE
feat: deploy oauth2-proxy and add Pocket-ID OIDC to Open WebUI

### DIFF
--- a/kubernetes/apps/cortex/open-webui/app/externalsecret.yaml
+++ b/kubernetes/apps/cortex/open-webui/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &secretname open-webui
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *secretname
+    template:
+      engineVersion: v2
+      data:
+        OAUTH_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: open-webui

--- a/kubernetes/apps/cortex/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/open-webui/app/helmrelease.yaml
@@ -29,6 +29,19 @@ spec:
               OPENAI_API_BASE_URL: "http://pipelines.cortex.svc.cluster.local:9099"
               OPENAI_API_KEY: "0p3n-w3bu!"
               PORT: &port 8080
+              ENABLE_OAUTH_SIGNUP: "true"
+              OAUTH_PROVIDER_NAME: "Pocket-ID"
+              OPENID_PROVIDER_URL: "https://auth.dcunha.io/.well-known/openid-configuration"
+              OAUTH_CLIENT_ID: "openwebui"
+              OAUTH_SCOPES: "openid profile email"
+              OAUTH_USERNAME_CLAIM: "preferred_username"
+              OAUTH_EMAIL_CLAIM: "email"
+              OAUTH_ROLES_CLAIM: "groups"
+              OAUTH_ALLOWED_ROLES: "admins,infra,users"
+              OAUTH_ADMIN_ROLES: "admins,infra"
+            envFrom:
+              - secretRef:
+                  name: open-webui
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/cortex/open-webui/app/kustomization.yaml
+++ b/kubernetes/apps/cortex/open-webui/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/security/oauth2-proxy/app/externalsecret.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &secretname oauth2-proxy
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *secretname
+    template:
+      engineVersion: v2
+      data:
+        OAUTH2_PROXY_CLIENT_SECRET: "{{ .OAUTH2_PROXY_CLIENT_SECRET }}"
+        OAUTH2_PROXY_COOKIE_SECRET: "{{ .OAUTH2_PROXY_COOKIE_SECRET }}"
+  dataFrom:
+    - extract:
+        key: oauth2-proxy

--- a/kubernetes/apps/security/oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: oauth2-proxy
+  interval: 1h
+  values:
+    controllers:
+      oauth2-proxy:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: quay.io/oauth2-proxy/oauth2-proxy
+              tag: v7.8.2
+            env:
+              OAUTH2_PROXY_PROVIDER: oidc
+              OAUTH2_PROXY_OIDC_ISSUER_URL: "https://auth.dcunha.io"
+              OAUTH2_PROXY_CLIENT_ID: oauth2-proxy
+              OAUTH2_PROXY_REDIRECT_URL: "https://oauth.dcunha.io/oauth2/callback"
+              OAUTH2_PROXY_UPSTREAM: "static://200"
+              OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4180"
+              OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+              OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+              OAUTH2_PROXY_COOKIE_DOMAINS: ".dcunha.io"
+              OAUTH2_PROXY_WHITELIST_DOMAINS: ".dcunha.io"
+              OAUTH2_PROXY_COOKIE_SECURE: "true"
+              OAUTH2_PROXY_COOKIE_SAMESITE: lax
+              OAUTH2_PROXY_COOKIE_NAME: _oauth2_proxy
+              OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
+              OAUTH2_PROXY_REVERSE_PROXY: "true"
+              OAUTH2_PROXY_SCOPE: "openid profile email"
+              OAUTH2_PROXY_CODE_CHALLENGE_METHOD: S256
+            envFrom:
+              - secretRef:
+                  name: oauth2-proxy
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: &port 4180
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ready
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        hostnames:
+          - "oauth.dcunha.io"
+        parentRefs:
+          - name: internal-gateway
+            namespace: network

--- a/kubernetes/apps/security/oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/app/kustomization.yaml
@@ -2,12 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: security
-
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  - ./pocket-id/ks.yaml
-  - ./oauth2-proxy/ks.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./referencegrant.yaml

--- a/kubernetes/apps/security/oauth2-proxy/app/ocirepository.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: oauth2-proxy
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/security/oauth2-proxy/app/referencegrant.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/app/referencegrant.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/referencegrant_v1beta1.json
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: from-security-policy
+  namespace: security
+spec:
+  from:
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: home-automation
+  to:
+    - group: ""
+      kind: Service
+      name: oauth2-proxy

--- a/kubernetes/apps/security/oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/security/oauth2-proxy/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app oauth2-proxy
+spec:
+  targetNamespace: security
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: pocket-id
+      namespace: security
+  path: ./kubernetes/apps/security/oauth2-proxy/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 1h


### PR DESCRIPTION
## Summary
- Deploy oauth2-proxy in `security` namespace backed by Pocket-ID OIDC with PKCE S256; exposed at `oauth.dcunha.io` for the callback flow
- Add ReferenceGrant so SecurityPolicies in other namespaces can reference the oauth2-proxy service cross-namespace
- Configure Open WebUI native OIDC against Pocket-ID (`openwebui` client); group-based role mapping: `admins`/`infra` → Admin, `users` → User

## Test plan
- [x] oauth2-proxy OIDC flow completes successfully via `oauth.dcunha.io`
- [x] Open WebUI shows "Continue with Pocket-ID" button and SSO login works
- [x] Open WebUI creates user with correct admin role from group membership