### PR TITLE
feat(components): add oauth2-proxy SecurityPolicy component

### DIFF
--- a/kubernetes/components/oauth2-proxy/kustomization.yaml
+++ b/kubernetes/components/oauth2-proxy/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./securitypolicy.yaml

--- a/kubernetes/components/oauth2-proxy/securitypolicy.yaml
+++ b/kubernetes/components/oauth2-proxy/securitypolicy.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: ${APP}-oauth2-proxy
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: ${OAUTH2_PROXY_HTTPROUTE:=${APP}}
+  extAuth:
+    http:
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: oauth2-proxy
+          namespace: security
+          port: 4180


### PR DESCRIPTION
## Summary
- Reusable Kustomize component that creates a SecurityPolicy wiring any HTTPRoute to the shared oauth2-proxy ExtAuthz service
- Uses `${APP}` for the route name by default; override with `${OAUTH2_PROXY_HTTPROUTE}` when the route name differs

## Usage
```yaml
components:
  - ../../../../components/oauth2-proxy
postBuild:
  substitute:
    APP: *app
    # OAUTH2_PROXY_HTTPROUTE: custom-route-name  # optional override
```