### PR TITLE
fix(security): expose pocket-id on external gateway

### DIFF
--- a/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
@@ -81,7 +81,7 @@ spec:
         hostnames:
           - "auth.dcunha.io"
         parentRefs:
-          - name: internal-gateway
+          - name: external-gateway
             namespace: network
 
     persistence:


### PR DESCRIPTION
## Summary
- Switches pocket-id's HTTPRoute from `internal-gateway` to `external-gateway` so users outside the LAN can reach `auth.dcunha.io`

## Test plan
- [x] Applied via `just kube apply-ks` and confirmed `auth.dcunha.io` is reachable externally