### PR TITLE
feat(default): add Pocket-ID OIDC to Immich

### DIFF
--- a/kubernetes/apps/default/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/default/immich/app/externalsecret.yaml
@@ -15,6 +15,20 @@ spec:
       data:
         DB_PASSWORD: "{{ .DB_PASSWORD }}"
         POSTGRES_PASSWORD: "{{ .DB_PASSWORD }}"
+        immich.json: |
+          {
+            "oauth": {
+              "enabled": true,
+              "issuerUrl": "https://auth.dcunha.io",
+              "clientId": "immich",
+              "clientSecret": "{{ .IMMICH_OIDC_CLIENT_SECRET }}",
+              "scope": "openid profile email",
+              "buttonText": "Login with Pocket ID",
+              "autoRegister": true,
+              "autoLaunch": false,
+              "mobileOverrideEnabled": false
+            }
+          }
   dataFrom:
     - extract:
         key: immich

--- a/kubernetes/apps/default/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/helmrelease.yaml
@@ -33,6 +33,7 @@ spec:
               DB_DATABASE_NAME: immich
               REDIS_HOSTNAME: immich-redis.default.svc.cluster.local
               IMMICH_MACHINE_LEARNING_URL: http://immich-machine-learning.default.svc.cluster.local:3003
+              IMMICH_CONFIG_FILE: /config/immich.json
             envFrom:
               - secretRef:
                   name: immich
@@ -221,6 +222,15 @@ spec:
           machine-learning:
             app:
               - path: /cache
+      config:
+        type: secret
+        name: immich
+        advancedMounts:
+          server:
+            app:
+              - path: /config/immich.json
+                subPath: immich.json
+                readOnly: true
       tmp:
         type: emptyDir
         advancedMounts:


### PR DESCRIPTION
## Summary
- Adds `IMMICH_CONFIG_FILE` env var pointing to a mounted JSON config
- ExternalSecret generates the config with OAuth settings, pulling `IMMICH_OIDC_CLIENT_SECRET` from the immich 1Password item
- Pocket-ID client ID: `immich`, redirect URI: `https://photos.dcunha.io/api/oauth/callback`
- "Login with Pocket ID" button on the login page; auto-registers new users

## Test plan
- [x] Applied via `just kube apply-ks` and confirmed "Login with Pocket ID" button appears at `https://photos.dcunha.io`