### PR TITLE
fix(observability): add PodMonitor for flux-operator

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/podmonitor.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/podmonitor.yaml
@@ -20,3 +20,19 @@ spec:
           - source-controller
           - kustomize-controller
           - notification-controller
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: flux-operator
+spec:
+  namespaceSelector:
+    matchNames:
+      - flux-system
+  podMetricsEndpoints:
+    - honorLabels: true
+      port: http-metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flux-operator


### PR DESCRIPTION
## Summary
- Adds a second `PodMonitor` (`flux-operator`) to `flux-instance/app/podmonitor.yaml`
- The existing `flux-components` PodMonitor only covered the four Flux controllers (helm/source/kustomize/notification), which use `app.kubernetes.io/component` labels
- The `flux-operator` pod uses `app.kubernetes.io/name=flux-operator` and exposes `flux_instance_info` on port `http-metrics` (8080) — without this, kromgo's `flux_version` badge always returned no data

## Test plan
- [x] `flux_instance_info` metric confirmed in Prometheus (1 result, `revision=v2.8.7@sha256:...`)
- [x] Prometheus target `podMonitor/flux-system/flux-operator/0` is `up`