### PR TITLE
feat(shelfmark): Envoy native OIDC via Pocket-ID, expose externally

### DIFF
--- a/.agents/skills/add-oidc-app/SKILL.md
+++ b/.agents/skills/add-oidc-app/SKILL.md
@@ -87,15 +87,56 @@ env:
     GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "contains(groups[*], 'admins') && 'Admin' || contains(groups[*], 'infra') && 'Editor' || 'Viewer'"
 ```
 
-### oauth2-proxy (apps without native OIDC)
+### Envoy Gateway native OIDC (apps without native OIDC support)
 
-Use the existing `oauth2-proxy` at `oauth.dcunha.io` (security namespace). Add a SecurityPolicy to the app's HTTPRoute — see `kubernetes/apps/security/oauth2-proxy/` for the pattern.
+Use `SecurityPolicy.oidc` — Envoy handles the full OIDC flow (redirects, CSRF, token exchange) internally. No sidecar or proxy needed.
 
-Cookie secret must be exactly 16/24/32 bytes:
+**Do not use oauth2-proxy with Envoy ExtAuth.** Envoy's ExtAuth does not forward `Set-Cookie` from the auth service 302 redirect to the browser, so oauth2-proxy's CSRF cookie never reaches the client and every callback fails with "CSRF cookie not found". This is a fundamental Envoy limitation, not a config issue.
 
-```bash
-python3 -c "import os,base64; print(base64.urlsafe_b64encode(os.urandom(24)).decode().rstrip('='))"
+**ExternalSecret** — the Secret key must be literally `client-secret` (Envoy requirement):
+
+```yaml
+target:
+    template:
+        data:
+            client-secret: "{{ .<APP>__OIDC__CLIENT_SECRET }}"
+dataFrom:
+    - extract:
+          key: <app> # 1Password item name
 ```
+
+**SecurityPolicy** (`securitypolicy.yaml`):
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+    name: <app>
+    namespace: <namespace>
+spec:
+    targetRefs:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+          name: <app>
+    oidc:
+        provider:
+            issuer: https://auth.dcunha.io
+        clientID: <app>
+        clientSecret:
+            name: <app> # Secret with key `client-secret`
+        redirectURL: "https://<app-hostname>/oauth2/callback"
+        scopes:
+            - openid
+            - profile
+            - email
+        forwardAccessToken: false
+```
+
+Add `securitypolicy.yaml` to the app's `kustomization.yaml` resources list.
+
+Pocket-ID callback URL to register: `https://<app-hostname>/oauth2/callback`
 
 ## Step 5 — Test
 
@@ -112,4 +153,6 @@ Navigate to `https://<app-hostname>` — should redirect to Pocket-ID login.
 - **Existing account linking (django-allauth)**: if a local account already exists with the same email, allauth won't auto-link on first OIDC login — add `"EMAIL_AUTHENTICATION": true` to the `openid_connect` block in `PAPERLESS_SOCIALACCOUNT_PROVIDERS` to enable auto-connect by email
 - **Grafana user conflict**: if existing user has `isExternal=false`, OAuth won't link — delete via Grafana API and let OAuth recreate
 - **Home Assistant**: no external OIDC auth provider support in HA core — `type: oidc` does not exist
-- **oauth2-proxy cookie secret**: must be exactly 32 chars — use the `python3` command above, do not truncate
+- **Envoy native OIDC `clientSecret` key**: the K8s Secret referenced by `oidc.clientSecret.name` must contain a key literally named `client-secret` — any other key name and Envoy silently fails
+- **`passThroughAuthHeader`**: requires JWT validation settings (`jwt` block) — omit it entirely unless you also configure JWKS; use `forwardAccessToken: false` instead
+- **ExtAuth + oauth2-proxy is broken on Envoy**: CSRF cookie from the auth service 302 response is not forwarded to the browser — use native OIDC (`SecurityPolicy.oidc`) instead

--- a/.agents/skills/kubesearch/SKILL.md
+++ b/.agents/skills/kubesearch/SKILL.md
@@ -1,0 +1,77 @@
+# Skill: Kubesearch — Find Home-Ops Examples
+
+Search GitHub for real HelmRelease examples from other home-ops clusters and adapt the best one to Artemis-Cluster conventions.
+
+## Step 1 — Identify the Query
+
+Confirm the app name to search for (e.g. `sonarr`, `paperless-ngx`, `immich`). If the user is mid-task (e.g. deploying an app), the query is the app or chart name being deployed.
+
+## Step 2 — Search GitHub for HelmRelease Examples
+
+Search for `helmrelease.yaml` files under `kubernetes/apps` paths (standard home-ops layout):
+
+```bash
+PATH="$HOME/.local/share/mise/shims:$PATH" gh api \
+  "search/code?q=<app>+filename:helmrelease.yaml+path:kubernetes/apps&per_page=10" \
+  --jq '.items[] | {repo: .repository.full_name, path: .path, url: .html_url}'
+```
+
+If no results, broaden by dropping the path filter:
+
+```bash
+PATH="$HOME/.local/share/mise/shims:$PATH" gh api \
+  "search/code?q=<app>+filename:helmrelease.yaml&per_page=10" \
+  --jq '.items[] | {repo: .repository.full_name, path: .path, url: .html_url}'
+```
+
+**Prioritise results** in this order:
+
+1. `path` contains `kubernetes/apps` (home-ops layout)
+2. Well-known repos: `onedr0p/home-ops`, `gavinmcfall/home-ops`, `bjw-s/home-ops`
+3. Highest star count (visible in `.repository.stargazers_count`)
+
+## Step 3 — Fetch the Top Result
+
+Extract owner/repo and path from the chosen result, then fetch the raw content:
+
+```bash
+REPO="<owner>/<repo>"
+FILE="<path/to/helmrelease.yaml>"
+
+PATH="$HOME/.local/share/mise/shims:$PATH" gh api \
+  "repos/${REPO}/contents/${FILE}" \
+  --jq '.content' | base64 -d
+```
+
+Fetch 1–2 results if the first looks incomplete (e.g. it references other files or is a template stub like `.yaml.j2`).
+
+## Step 4 — Present and Adapt
+
+Show the fetched YAML and note the source URL. Then identify the key patterns:
+
+- **Image**: repository + tag or digest
+- **Environment variables**: app-specific env vars to carry forward
+- **Ports**: HTTP port number
+- **Persistence**: mount paths and PVC usage
+- **Secrets**: what env vars are sourced from secrets
+- **Security context**: `runAsUser`, `readOnlyRootFilesystem`, etc.
+
+Then adapt to Artemis-Cluster conventions:
+
+| Theirs                  | Artemis equivalent                                                              |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| Any chart source        | `OCIRepository` pointing to `oci://ghcr.io/bjw-s-labs/helm/app-template` (v5)   |
+| `secretRef` / `envFrom` | `ExternalSecret` via `onepassword-connect` ClusterSecretStore                   |
+| `Ingress`               | `HTTPRoute` via `internal-gateway` or `external-gateway` in `network` namespace |
+| `TZ: America/New_York`  | `TZ: America/Toronto`                                                           |
+| Any namespace           | Match user's target namespace for this cluster                                  |
+
+If the source repo already uses `app-template`, carry their `controllers`/`containers`/`persistence` structure directly — just update image, TZ, and secrets pattern.
+
+## Common Issues / Gotchas
+
+- **`.yaml.j2` results**: these are Jinja templates (gavinmcfall/home-ops uses them) — still useful for values, but skip the outer template syntax
+- **Pinned digest tags** (`image@sha256:...`): fine to copy, but note the user may want a mutable tag for easier updates
+- **`path:` filter misses some repos**: some clusters use `cluster/apps` or `apps/` — broaden the search if needed
+- **Rate limits**: `gh api` uses your authenticated token (higher limit than anonymous). If you hit a limit, wait and retry.
+- **Multiple instances** (e.g. Sonarr ×3): search returns any instance — check the values for instance-specific env vars like `SONARR__APP__INSTANCENAME`

--- a/.claude/commands/kubesearch.md
+++ b/.claude/commands/kubesearch.md
@@ -1,0 +1,1 @@
+See `.agents/skills/kubesearch/SKILL.md` for the full runbook.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Use `.agents/skills/` for repeatable cluster tasks:
 | `add-oidc-app/SKILL.md`      | "add SSO to X", "wire X into Pocket-ID", "set up OIDC for X", "add login to X", "single sign-on for X"                                                  |
 | `add-agent-content/SKILL.md` | "add a new skill", "add an instruction", "update .agents/", "document this as a runbook"                                                                |
 | `build-container/SKILL.md`   | "build a custom image for X", "no upstream image exists", "create a Dockerfile for X", "publish container to GHCR"                                      |
+| `kubesearch/SKILL.md`        | "find examples for X", "how do others deploy X", "search kubesearch for X", "look up X in home-ops repos", "what's a good helmrelease for X"            |
 
 ## Repo Structure
 

--- a/kubernetes/apps/media/shelfmark/app/externalsecret.yaml
+++ b/kubernetes/apps/media/shelfmark/app/externalsecret.yaml
@@ -14,6 +14,9 @@ spec:
       engineVersion: v2
       data:
         PROWLARR_API_KEY: "{{ .PROWLARR_API_KEY }}"
+        client-secret: "{{ .SHELFMARK__OIDC__CLIENT_SECRET }}"
   dataFrom:
     - extract:
         key: prowlarr
+    - extract:
+        key: shelfmark

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -80,7 +80,7 @@ spec:
         hostnames:
           - "booksearch.dcunha.io"
         parentRefs:
-          - name: internal-gateway
+          - name: external-gateway
             namespace: network
 
     persistence:

--- a/kubernetes/apps/media/shelfmark/app/kustomization.yaml
+++ b/kubernetes/apps/media/shelfmark/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/shelfmark/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/shelfmark/app/securitypolicy.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: shelfmark
+  namespace: media
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: shelfmark
+  oidc:
+    provider:
+      issuer: https://auth.dcunha.io
+    clientID: shelfmark
+    clientSecret:
+      name: shelfmark
+    redirectURL: "https://booksearch.dcunha.io/oauth2/callback"
+    scopes:
+      - openid
+      - profile
+      - email
+    forwardAccessToken: false


### PR DESCRIPTION
## Summary

- Adds `SecurityPolicy.oidc` to gate `booksearch.dcunha.io` through Pocket-ID natively — no oauth2-proxy needed
- Consolidates `ExternalSecret` to pull `PROWLARR_API_KEY` + `SHELFMARK__OIDC__CLIENT_SECRET` into one Secret (key `client-secret` required by Envoy)
- Moves HTTPRoute from `internal-gateway` to `external-gateway` for public access
- Updates `add-oidc-app` skill: documents Envoy native OIDC pattern, warns that oauth2-proxy+ExtAuth is broken on Envoy (CSRF cookie not forwarded from auth service 302)

## Why native OIDC instead of oauth2-proxy

Envoy Gateway's ExtAuth does not forward `Set-Cookie` headers from the auth service's 302 redirect response to the browser. oauth2-proxy's CSRF state cookie never reaches the client, so every callback fails with "CSRF cookie not found". `SecurityPolicy.oidc` handles the full OIDC flow (redirects, CSRF, token exchange) internally and works correctly.

## Test plan

- [x] `just kube apply-ks media shelfmark` — all resources serverside-applied
- [x] ExternalSecret: `SecretSynced`
- [x] SecurityPolicy: `Accepted` (observedGeneration 5)
- [x] HTTPRoute accepted on `external-gateway`
- [x] Pod healthy, gunicorn listening on 8084
- [x] `https://booksearch.dcunha.io` redirects to Pocket-ID login and returns to app after auth