### PR TITLE
feat(media): migrate shelfmark to native OIDC, add suwayomi Envoy OIDC

### DIFF
--- a/.agents/skills/add-oidc-app/SKILL.md
+++ b/.agents/skills/add-oidc-app/SKILL.md
@@ -25,12 +25,14 @@ Wire a new application into Pocket-ID for single sign-on. Pocket-ID is at `https
 
 Save to the app's 1Password item (create if needed). Key name depends on how the app reads it:
 
-| App pattern                    | Key name                              |
-| ------------------------------ | ------------------------------------- |
-| Env var prefix (e.g. bookboss) | `BOOKBOSS__OIDC__CLIENT_SECRET`       |
-| Generic oauth (e.g. Grafana)   | `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET` |
-| Spring OAuth2 (e.g. Komga)     | `KOMGA_OIDC_CLIENT_SECRET`            |
-| Open WebUI                     | `OAUTH_CLIENT_SECRET`                 |
+| App pattern                          | Key name                              |
+| ------------------------------------ | ------------------------------------- |
+| Env var prefix (e.g. bookboss)       | `BOOKBOSS__OIDC__CLIENT_SECRET`       |
+| Generic oauth (e.g. Grafana)         | `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET` |
+| Spring OAuth2 (e.g. Komga)           | `KOMGA_OIDC_CLIENT_SECRET`            |
+| Open WebUI                           | `OAUTH_CLIENT_SECRET`                 |
+| Shelfmark-style (`AUTH_METHOD=oidc`) | `OIDC_CLIENT_SECRET`                  |
+| Envoy native OIDC (SecurityPolicy)   | `client-secret` (Envoy hard-coded)    |
 
 ## Step 3 — Add ExternalSecret
 
@@ -86,6 +88,21 @@ env:
     # Role mapping via JMESPath (groups claim):
     GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: "contains(groups[*], 'admins') && 'Admin' || contains(groups[*], 'infra') && 'Editor' || 'Viewer'"
 ```
+
+### Shelfmark-style native OIDC (`AUTH_METHOD=oidc`)
+
+Apps that expose OIDC via env vars with `AUTH_METHOD=oidc`:
+
+```yaml
+env:
+    AUTH_METHOD: oidc
+    OIDC_DISCOVERY_URL: "https://auth.dcunha.io/.well-known/openid-configuration"
+    OIDC_CLIENT_ID: <app>
+    OIDC_ADMIN_GROUP: admins
+    OIDC_AUTO_REDIRECT: "true"
+```
+
+`OIDC_CLIENT_SECRET` injected from Secret via `envFrom`. Callback URL: `https://<hostname>/api/auth/oidc/callback`. PKCE: disable on Pocket-ID client (uses authlib).
 
 ### Envoy Gateway native OIDC (apps without native OIDC support)
 

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -26,6 +26,11 @@ spec:
               FLASK_PORT: &port 8084
               INGEST_DIR: /media/book-ingest
               PROWLARR_URL: http://prowlarr.media.svc.cluster.local:80
+              AUTH_METHOD: oidc
+              OIDC_DISCOVERY_URL: "https://auth.dcunha.io/.well-known/openid-configuration"
+              OIDC_CLIENT_ID: shelfmark
+              OIDC_ADMIN_GROUP: admins
+              OIDC_AUTO_REDIRECT: "true"
             envFrom:
               - secretRef:
                   name: shelfmark

--- a/kubernetes/apps/media/shelfmark/app/kustomization.yaml
+++ b/kubernetes/apps/media/shelfmark/app/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
-  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/suwayomi/app/externalsecret.yaml
+++ b/kubernetes/apps/media/suwayomi/app/externalsecret.yaml
@@ -3,7 +3,7 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: &secretname shelfmark
+  name: &secretname suwayomi
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
@@ -13,10 +13,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        PROWLARR_API_KEY: "{{ .PROWLARR_API_KEY }}"
-        OIDC_CLIENT_SECRET: "{{ .SHELFMARK__OIDC__CLIENT_SECRET }}"
+        client-secret: "{{ .SUWAYOMI__OIDC__CLIENT_SECRET }}"
   dataFrom:
     - extract:
-        key: prowlarr
-    - extract:
-        key: shelfmark
+        key: suwayomi

--- a/kubernetes/apps/media/suwayomi/app/helmrelease.yaml
+++ b/kubernetes/apps/media/suwayomi/app/helmrelease.yaml
@@ -80,7 +80,7 @@ spec:
         hostnames:
           - "suwayomi.dcunha.io"
         parentRefs:
-          - name: internal-gateway
+          - name: external-gateway
             namespace: network
 
     persistence:

--- a/kubernetes/apps/media/suwayomi/app/kustomization.yaml
+++ b/kubernetes/apps/media/suwayomi/app/kustomization.yaml
@@ -3,5 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/suwayomi/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/suwayomi/app/securitypolicy.yaml
@@ -3,20 +3,20 @@
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  name: shelfmark
+  name: suwayomi
   namespace: media
 spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: shelfmark
+      name: suwayomi
   oidc:
     provider:
       issuer: https://auth.dcunha.io
-    clientID: shelfmark
+    clientID: suwayomi
     clientSecret:
-      name: shelfmark
-    redirectURL: "https://booksearch.dcunha.io/oauth2/callback"
+      name: suwayomi
+    redirectURL: "https://suwayomi.dcunha.io/oauth2/callback"
     scopes:
       - openid
       - profile


### PR DESCRIPTION
## Summary

- **shelfmark**: switches from `SecurityPolicy.oidc` to app-native OIDC (`AUTH_METHOD=oidc`); removes SecurityPolicy; renames ExternalSecret key to `OIDC_CLIENT_SECRET`; sets `OIDC_AUTO_REDIRECT=true` and `OIDC_ADMIN_GROUP=admins`
- **suwayomi**: adds `SecurityPolicy.oidc` + ExternalSecret for Pocket-ID gate; moves route to `external-gateway`

## Test plan

- [x] shelfmark ExternalSecret: `SecretSynced`
- [x] shelfmark pod rolled out with native OIDC env vars
- [x] `https://booksearch.dcunha.io` auto-redirects to Pocket-ID and returns authenticated
- [x] suwayomi ExternalSecret: `SecretSynced`
- [x] suwayomi SecurityPolicy: `Accepted`
- [x] `https://suwayomi.dcunha.io` redirects to Pocket-ID login