### PR TITLE
feat(observability): add pve-exporter, truenas-exporter, and unpoller alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,3 +132,4 @@ Task runner: `just` (`bootstrap/mod.just`, `kubernetes/mod.just`)
 - **Rook-Ceph mgr/mon crash**: remove `device_failure_prediction_mode: local` from cephConfig (requires `diskprediction_local` module which isn't enabled)
 - **SABnzbd P2 expired**: NewsDemon `news.newsdemon.com` expired 2026-04-21 — remove from SABnzbd servers
 - **Eaton UPS**: batteries dead — not providing real protection
+- **TrueNAS netdata.conf**: `/etc/netdata/netdata.conf` must be replaced after every TrueNAS update — run `curl -s https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/main/netdata.conf | sudo tee /etc/netdata/netdata.conf && sudo systemctl restart netdata` on atlas (10.10.99.100); without this, metrics exported to the graphite bridge are incomplete

--- a/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
@@ -13,15 +13,6 @@ spec:
     fullnameOverride: blackbox-exporter
     config:
       modules:
-        http_2xx:
-          prober: http
-          timeout: 5s
-          http:
-            valid_http_versions:
-              - HTTP/1.1
-              - HTTP/2.0
-            follow_redirects: true
-            preferred_ip_protocol: ip4
         icmp:
           prober: icmp
           timeout: 5s

--- a/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
@@ -12,11 +12,6 @@ spec:
   targets:
     staticConfig:
       static:
-        # --- Network / Core ---
-        - 10.10.99.1 # UCG-Max (Gateway)
-        - 10.10.99.100 # TrueNAS Scale
-        - 10.10.99.104 # Proxmox
-
         # --- Talos Control Plane ---
         - 10.10.99.101 # talos-cp-01
         - 10.10.99.102 # talos-cp-02
@@ -45,25 +40,6 @@ spec:
     staticConfig:
       static:
         - 10.10.99.100:2049 # TrueNAS NFS
-  metricRelabelings:
-    - targetLabel: service
-      replacement: blackbox-exporter
-      action: replace
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/probe_v1.json
-apiVersion: monitoring.coreos.com/v1
-kind: Probe
-metadata:
-  name: http
-spec:
-  jobName: blackbox-http
-  module: http_2xx
-  prober:
-    url: blackbox-exporter.observability.svc.cluster.local:9115
-  targets:
-    staticConfig:
-      static:
-        - https://unifi.dcunha.io
   metricRelabelings:
     - targetLabel: service
       replacement: blackbox-exporter

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
   - ./kube-prometheus-stack/ks.yaml
   - ./silence-operator/ks.yaml
   - ./kromgo/ks.yaml
+  - ./pve-exporter/ks.yaml
   - ./smartctl-exporter/ks.yaml
+  - ./truenas-exporter/ks.yaml
   - ./unpoller/ks.yaml
   - ./victoria-logs/ks.yaml

--- a/kubernetes/apps/observability/pve-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/pve-exporter/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pve-exporter
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: pve-exporter-secret
+    template:
+      data:
+        PVE_USER: "{{ .PVE_USER }}"
+        PVE_TOKEN_NAME: "{{ .PVE_TOKEN_NAME }}"
+        PVE_TOKEN_VALUE: "{{ .PVE_TOKEN_VALUE }}"
+  dataFrom:
+    - extract:
+        key: proxmox

--- a/kubernetes/apps/observability/pve-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/pve-exporter/app/grafanadashboard.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: proxmox-via-prometheus
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/10347/revisions/5/download

--- a/kubernetes/apps/observability/pve-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/pve-exporter/app/helmrelease.yaml
@@ -1,0 +1,66 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pve-exporter
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: pve-exporter
+  interval: 1h
+  values:
+    controllers:
+      pve-exporter:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/prometheus-pve/prometheus-pve-exporter
+              tag: 3.8.3@sha256:4527b8080c4bd53ae8d7326ff7a3469dad0c1abb5753ff0bae9f1ef1c23cb2c9
+            env:
+              PYTHONWARNINGS: once
+              PVE_VERIFY_SSL: "false"
+            envFrom:
+              - secretRef:
+                  name: pve-exporter-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 64Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    service:
+      app:
+        ports:
+          metrics:
+            port: 9221
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: metrics
+            path: /pve
+            params:
+              target:
+                - 10.10.99.104:8006
+            interval: 60s
+            scrapeTimeout: 30s
+            metricRelabelings:
+              - action: labeldrop
+                regex: (pod)
+              - action: replace
+                sourceLabels:
+                  - __param_target
+                targetLabel: instance

--- a/kubernetes/apps/observability/pve-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/pve-exporter/app/kustomization.yaml
@@ -8,4 +8,3 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
-  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/pve-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/pve-exporter/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: pve-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/pve-exporter/ks.yaml
+++ b/kubernetes/apps/observability/pve-exporter/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pve-exporter
+spec:
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/observability/pve-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 1h

--- a/kubernetes/apps/observability/truenas-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/grafanadashboard.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: truenas-scale
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_MIMIR
+  url: https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/main/dashboards/truenas_scale.json
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: truenas-scale-disk-insights
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_MIMIR
+  url: https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/main/dashboards/truenas_scale_disk_insights.json
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: truenas-scale-temperatures
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/main/dashboards/truenas_scale_temperatures.json

--- a/kubernetes/apps/observability/truenas-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/helmrelease.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: truenas-exporter
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: truenas-exporter
+  interval: 1h
+  values:
+    controllers:
+      truenas-exporter:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/supporterino/truenas-graphite-to-prometheus
+              tag: v2.2.1
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 64Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+    service:
+      app:
+        # TrueNAS (10.10.99.100) pushes graphite metrics to port 9109
+        # Prometheus scrapes converted metrics from port 9108
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: 10.10.99.93
+        ports:
+          metrics:
+            port: 9108
+          graphite:
+            port: 9109
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: metrics
+            interval: 1m
+            scrapeTimeout: 30s

--- a/kubernetes/apps/observability/truenas-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/kustomization.yaml
@@ -4,8 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: observability
 resources:
-  - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
-  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/truenas-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: truenas-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/truenas-exporter/ks.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app truenas-exporter
+spec:
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/observability/truenas-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 1h

--- a/kubernetes/apps/observability/unpoller/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/unpoller/app/prometheusrule.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: unpoller
+spec:
+  groups:
+    - name: unpoller
+      rules:
+        - alert: UnifiControllerDown
+          expr: unpoller_controller_up == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: UniFi controller unreachable
+            description: The UniFi controller at {{ $labels.source }} has been unreachable for 5 minutes.
+
+        - alert: UnifiDeviceRebooted
+          expr: unpoller_device_uptime_seconds < 300
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: UniFi device recently rebooted
+            description: Device {{ $labels.name }} ({{ $labels.type }}) has uptime under 5 minutes.
+
+        - alert: UnifiHighInternetDrops
+          expr: increase(unpoller_site_intenet_drops_total[1h]) > 5
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: High internet drop count on UniFi site
+            description: Site {{ $labels.site_name }} has had {{ $value | humanize }} internet drops in the last hour.


### PR DESCRIPTION
## Summary

- **pve-exporter**: Proxmox VE metrics via `prometheus-pve-exporter` using proxy scrape pattern (`/pve?target=10.10.99.104:8006`); credentials from 1Password `proxmox` item; Grafana dashboard #10347
- **truenas-exporter**: TrueNAS SCALE 25.04 metrics via graphite bridge (`supporterino/truenas-graphite-to-prometheus:v2.2.1`); LoadBalancer IP `10.10.99.93`; TrueNAS pushes Graphite to port 9109, Prometheus scrapes converted metrics from port 9108; 3 Grafana dashboards (overview, disk insights, temperatures)
- **unpoller**: PrometheusRule with alerts for controller down, device rebooted, and high internet drops
- **blackbox**: removed appliance ICMP probes (UCG-Max, TrueNAS, Proxmox) now covered by dedicated exporters; removed unused `http_2xx` module

## Notes

- TrueNAS requires a static route `10.10.99.64/26 via 10.10.99.1` (Cilium LB pool not ARP-reachable from same subnet) — add via TrueNAS UI: Network → Static Routes
- TrueNAS Graphite reporter must use prefix `truenas` and hostname `atlas`
- `/etc/netdata/netdata.conf` on TrueNAS must be replaced with the one from the supporterino repo to restore 25.04-dropped metrics (not persistent across TrueNAS updates)