### PR TITLE
fix(kromgo): update to v0.10.0, fix config queries and badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _... where YAML is law, Renovate never sleeps, and 2am <br>is just debugging hou
 
 [![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.dcunha.io%2Fquery%3Fformat%3Dendpoint%26metric%3Dtalos_version&style=for-the-badge&logo=talos&logoColor=white&color=blue&label=talos)](https://www.talos.dev/)&nbsp;&nbsp;
 [![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.dcunha.io%2Fquery%3Fformat%3Dendpoint%26metric%3Dkubernetes_version&style=for-the-badge&logo=kubernetes&logoColor=white&color=blue&label=k8s)](https://kubernetes.io/)&nbsp;&nbsp;
-[![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.dcunha.io%2Fflux_version&style=for-the-badge&logo=flux&logoColor=white&color=blue&label=flux)](https://fluxcd.io)&nbsp;&nbsp;
+[![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.dcunha.io%2Fquery%3Fformat%3Dendpoint%26metric%3Dflux_version&style=for-the-badge&logo=flux&logoColor=white&color=blue&label=flux)](https://fluxcd.io)&nbsp;&nbsp;
 [![Renovate](https://img.shields.io/github/actions/workflow/status/Exikle/Artemis-Cluster/renovate.yaml?branch=main&label=&logo=renovatebot&style=for-the-badge&color=blue)](https://github.com/Exikle/Artemis-Cluster/actions/workflows/renovate.yaml)
 
 [![Home-Internet](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus.dcunha.io%2Fapi%2Fv1%2Fendpoints%2Fcore_ping%2Fhealth%2Fbadge.shields&style=for-the-badge&logo=ubiquiti&logoColor=white&label=Home%20Internet)](https://status.dcunha.io)&nbsp;&nbsp;

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
           app:
             image:
               repository: ghcr.io/kashalls/kromgo
-              tag: v0.9.1@sha256:1624b1a10009978243d7d54e83269cbf9e3a4ec7f14c2548bdd11e63db5c4ad7
+              tag: v0.10.0@sha256:965ecc92d68dc1a4a969397855367bbc70da03227a941ea607b73bb7e0b78fd6
             env:
               PROMETHEUS_URL: http://prometheus-operated.observability.svc.cluster.local:9090
               SERVER_PORT: &port 80

--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -16,7 +16,7 @@ metrics:
     title: Kubernetes
 
   - name: flux_version
-    query: label_replace(flux_instance_info, "revision", "$1", "revision", "v(.+)@sha256:.+")
+    query: label_replace(flux_instance_info{job="flux-system/flux-operator"}, "revision", "$1", "revision", "v(.+)@sha256:.+")
     label: revision
     title: Flux
 
@@ -69,7 +69,7 @@ metrics:
     title: Uptime
 
   - name: cluster_alert_count
-    query: alertmanager_alerts{state="active"} - 1 # Ignore Watchdog
+    query: sum(alertmanager_alerts{state="active"}) - 1 # Ignore Watchdog
     colors:
       - {color: "green", min: 0, max: 0}
       - {color: "red", min: 1, max: 9999}

--- a/kubernetes/apps/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/observability/kromgo/ks.yaml
@@ -10,6 +10,8 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: kromgo
+  dependsOn:
+    - name: kube-prometheus-stack
   path: ./kubernetes/apps/observability/kromgo/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary
- Bump image `v0.9.1` → `v0.10.0` (upstream fix for incorrect byte mapping in badge rendering)
- Fix Flux badge URL in README — was missing `format=endpoint`, breaking the shields.io endpoint format
- Pin `flux_instance_info` query with `{job="flux-system/flux-operator"}` to avoid returning duplicate series from dual ServiceMonitors
- Wrap `cluster_alert_count` in `sum()` for correctness when alertmanager scales beyond 1 replica
- Add `dependsOn: kube-prometheus-stack` to `ks.yaml` so Flux orders startup correctly

## Test plan
- [x] Applied locally with `just kube apply-ks observability kromgo`
- [x] HelmRelease upgraded to `.v22`, pod running `v0.10.0` confirmed