### PR TITLE
fix(media): harden paperless security context and sort manifests

### DIFF
--- a/kubernetes/apps/media/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/media/paperless/app/externalsecret.yaml
@@ -5,19 +5,19 @@ kind: ExternalSecret
 metadata:
   name: &secretname paperless
 spec:
+  dataFrom:
+    - extract:
+        key: paperless
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
     name: *secretname
     template:
-      engineVersion: v2
       data:
         PAPERLESS_SECRET_KEY: "{{ .PAPERLESS_SECRET_KEY }}"
         PAPERLESS_ADMIN_USER: "{{ .PAPERLESS_ADMIN_USER }}"
         PAPERLESS_ADMIN_PASSWORD: "{{ .PAPERLESS_ADMIN_PASSWORD }}"
         PAPERLESS_SOCIALACCOUNT_PROVIDERS: |
           {"openid_connect": {"EMAIL_AUTHENTICATION": true, "APPS": [{"provider_id": "pocket-id", "name": "Pocket-ID", "client_id": "paperless", "secret": "{{ .PAPERLESS_OIDC_CLIENT_SECRET }}", "settings": {"server_url": "https://auth.dcunha.io"}}]}}
-  dataFrom:
-    - extract:
-        key: paperless
+      engineVersion: v2

--- a/kubernetes/apps/media/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/media/paperless/app/helmrelease.yaml
@@ -10,6 +10,11 @@ spec:
     name: paperless
   interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
     controllers:
       paperless:
         annotations:
@@ -51,49 +56,32 @@ spec:
                 enabled: true
                 custom: true
                 spec:
+                  failureThreshold: 5
                   httpGet:
                     path: /
                     port: &port 8000
                   initialDelaySeconds: 30
                   periodSeconds: 30
                   timeoutSeconds: 5
-                  failureThreshold: 5
               readiness:
                 enabled: true
                 custom: true
                 spec:
+                  failureThreshold: 5
                   httpGet:
                     path: /
                     port: *port
                   initialDelaySeconds: 30
                   periodSeconds: 10
                   timeoutSeconds: 5
-                  failureThreshold: 5
             resources:
               requests:
                 cpu: 100m
                 memory: 512Mi
               limits:
                 memory: 2Gi
-
-    defaultPodOptions:
-      securityContext:
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
-
-    service:
-      app:
-        ports:
-          http:
-            port: *port
-
-    route:
-      app:
-        hostnames:
-          - "paperless.dcunha.io"
-        parentRefs:
-          - name: internal-gateway
-            namespace: network
+            securityContext:
+              allowPrivilegeEscalation: false
 
     persistence:
       config:
@@ -102,8 +90,8 @@ spec:
           - path: /data
       ocr:
         type: nfs
-        server: 10.10.99.100
         path: /mnt/atlas/media/scanned-documents
+        server: 10.10.99.100
         globalMounts:
           - path: /ingest
             subPath: ingest
@@ -113,3 +101,17 @@ spec:
             subPath: export
       tmp:
         type: emptyDir
+
+    route:
+      app:
+        hostnames:
+          - "paperless.dcunha.io"
+        parentRefs:
+          - name: internal-gateway
+            namespace: network
+
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/media/paperless/database/helmrelease.yaml
+++ b/kubernetes/apps/media/paperless/database/helmrelease.yaml
@@ -14,14 +14,14 @@ spec:
       valkey:
         pod:
           securityContext:
+            runAsGroup: 999
             runAsNonRoot: true
             runAsUser: 999
-            runAsGroup: 999
         containers:
           app:
             image:
               repository: docker.io/valkey/valkey
-              tag: 9-alpine
+              tag: 9.0.4-alpine@sha256:aba3ce55601d0cf7e121fc3c5d9e23bea99bd0df5466500df46c157313226d2e
             args:
               - --save
               - ""

--- a/kubernetes/apps/media/paperless/gotenberg/helmrelease.yaml
+++ b/kubernetes/apps/media/paperless/gotenberg/helmrelease.yaml
@@ -12,11 +12,18 @@ spec:
   values:
     controllers:
       gotenberg:
+        pod:
+          securityContext:
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
         containers:
           app:
             image:
               repository: docker.io/gotenberg/gotenberg
-              tag: "8"
+              tag: 8.32.0@sha256:dd194920cf51c547854f719be8cd986e531c445419ad63d42654c5b906f22bbe
             args:
               - gotenberg
               - --chromium-disable-javascript=true
@@ -32,9 +39,6 @@ spec:
               capabilities:
                 drop:
                   - ALL
-              runAsNonRoot: true
-              runAsUser: 1001
-              runAsGroup: 1001
 
     service:
       app:

--- a/kubernetes/apps/media/paperless/ks.yaml
+++ b/kubernetes/apps/media/paperless/ks.yaml
@@ -3,52 +3,23 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app paperless-database
+  name: paperless-database
 spec:
-  targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: paperless
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
+  interval: 1h
   path: ./kubernetes/apps/media/paperless/database
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
-  interval: 1h
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: paperless-app
-spec:
   targetNamespace: media
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: paperless
-  dependsOn:
-    - name: paperless-database
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
-  path: ./kubernetes/apps/media/paperless/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
-  interval: 1h
-  postBuild:
-    substitute:
-      APP: paperless
-      VOLSYNC_CAPACITY: 5Gi
-  components:
-    - ../../../../components/volsync
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -56,20 +27,18 @@ kind: Kustomization
 metadata:
   name: paperless-tika
 spec:
-  targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: paperless
-  dependsOn:
-    - name: paperless-app
+  interval: 1h
   path: ./kubernetes/apps/media/paperless/tika
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false
-  interval: 1h
+  targetNamespace: media
+  wait: true
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -77,17 +46,44 @@ kind: Kustomization
 metadata:
   name: paperless-gotenberg
 spec:
-  targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: paperless
-  dependsOn:
-    - name: paperless-app
+  interval: 1h
   path: ./kubernetes/apps/media/paperless/gotenberg
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false
+  targetNamespace: media
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: paperless-app
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: paperless
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: paperless-database
+    - name: paperless-tika
+    - name: paperless-gotenberg
   interval: 1h
+  path: ./kubernetes/apps/media/paperless/app
+  postBuild:
+    substitute:
+      APP: paperless
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  wait: true

--- a/kubernetes/apps/media/paperless/tika/helmrelease.yaml
+++ b/kubernetes/apps/media/paperless/tika/helmrelease.yaml
@@ -12,11 +12,18 @@ spec:
   values:
     controllers:
       tika:
+        pod:
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
         containers:
           app:
             image:
               repository: docker.io/apache/tika
-              tag: latest-full
+              tag: 3.3.0.0-full@sha256:ed28cbbf59bc9e06eae6f99891a8e6d197cefdc278a296e30a135684e34ca320
             resources:
               requests:
                 cpu: 50m


### PR DESCRIPTION
## Summary

- Fix Flux Kustomization dependency order: `paperless-tika` and `paperless-gotenberg` are now prerequisites of `paperless-app` (previously inverted)
- Pin all floating image tags with exact versions and SHA digests (tika `latest-full` → `3.3.0.0-full`, gotenberg `"8"` → `8.32.0`, valkey `9-alpine` → `9.0.4-alpine`)
- Add pod-level `securityContext` to tika (`runAsNonRoot`, `fsGroup`, `fsGroupChangePolicy`) and fix gotenberg to use pod-level instead of container-level for the same fields
- Add `allowPrivilegeEscalation: false` to main paperless-ngx container
- Remove redundant `rook-ceph-cluster` dep from `paperless-app` (already transitive via `paperless-database`)
- Remove dead `&app` anchor from `ks.yaml`
- Sort all manifests per project conventions

## Test plan

- [x] All four HelmReleases reconciled successfully in `media` namespace
- [x] All pods running with correct pinned image digests verified live
- [x] Removed pre-existing orphaned `paperless-tika` and `paperless-gotenberg` HelmReleases/OCIRepositories from `default` namespace