### PR TITLE
chore(home-automation): bring esphome, mosquitto, matter-server to convention

### DIFF
--- a/kubernetes/apps/home-automation/esphome/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/esphome/app/externalsecret.yaml
@@ -5,6 +5,10 @@ kind: ExternalSecret
 metadata:
   name: esphome-secrets
 spec:
+  dataFrom:
+    - extract:
+        key: esphome
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
@@ -13,12 +17,9 @@ spec:
     template:
       engineVersion: v2
       data:
-        secrets.yaml: |
+        secrets.yaml: |-
           wifi_ssid: "{{ .WIFI_SSID }}"
           wifi_password: "{{ .WIFI_PASSWORD }}"
           api_encryption_key: "{{ .API_ENCRYPTION_KEY }}"
           ota_password: "{{ .OTA_PASSWORD }}"
           fallback_hotspot_password: "{{ .FALLBACK_HOTSPOT_PASSWORD }}"
-  dataFrom:
-    - extract:
-        key: esphome

--- a/kubernetes/apps/home-automation/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/esphome/app/helmrelease.yaml
@@ -10,6 +10,24 @@ spec:
     name: esphome
   interval: 1h
   values:
+    defaultPodOptions:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "iot",
+            "namespace": "kube-system",
+            "ips": [
+              "10.10.152.13/24",
+              "fd00:10:10:152::13/64"
+            ],
+            "mac": "02:4d:60:0e:5e:0d"
+          }]
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
     controllers:
       esphome:
         annotations:
@@ -26,52 +44,18 @@ spec:
                 enabled: false
               startup:
                 enabled: false
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities:
-                drop:
-                  - ALL
             resources:
               requests:
                 cpu: 5m
                 memory: 512Mi
               limits:
                 memory: 3Gi
-    defaultPodOptions:
-      annotations:
-        k8s.v1.cni.cncf.io/networks: |-
-          [{
-            "name": "iot",
-            "namespace": "kube-system",
-            "ips": [
-              "10.10.152.13/24",
-              "fd00:10:10:152::13/64"
-            ],
-            "mac": "02:4d:60:0e:5e:0d"
-          }]
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
-    service:
-      app:
-        ports:
-          http:
-            port: 6052
-    route:
-      app:
-        hostnames:
-          - "{{ .Release.Name }}.dcunha.io"
-        parentRefs:
-          - name: internal-gateway
-            namespace: network
-        rules:
-          - backendRefs:
-              - name: "{{ .Release.Name }}"
-                port: 6052
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"
@@ -84,9 +68,9 @@ spec:
           - path: /config/secrets.yaml
             subPath: secrets.yaml
       buildcache:
-        suffix: buildcache
-        size: 10Gi
         accessMode: ReadWriteOnce
+        size: 10Gi
+        suffix: buildcache
         advancedMounts:
           esphome:
             app:
@@ -98,3 +82,19 @@ spec:
             app:
               - path: /tmp
                 subPath: tmp
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.dcunha.io"
+        parentRefs:
+          - name: internal-gateway
+            namespace: network
+        rules:
+          - backendRefs:
+              - name: "{{ .Release.Name }}"
+                port: 6052
+    service:
+      app:
+        ports:
+          http:
+            port: 6052

--- a/kubernetes/apps/home-automation/esphome/ks.yaml
+++ b/kubernetes/apps/home-automation/esphome/ks.yaml
@@ -5,12 +5,18 @@ kind: Kustomization
 metadata:
   name: &app esphome
 spec:
-  components:
-    - ../../../../components/volsync
   targetNamespace: home-automation
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/home-automation/esphome/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  wait: true
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
@@ -18,16 +24,10 @@ spec:
       namespace: kube-system
     - name: external-secrets
       namespace: external-secrets
-  path: ./kubernetes/apps/home-automation/esphome/app
+  components:
+    - ../../../../components/volsync
   postBuild:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
       VOLSYNC_SCHEDULE: "50 * * * *"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  wait: true
-  interval: 1h

--- a/kubernetes/apps/home-automation/matter-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/matter-server/app/helmrelease.yaml
@@ -10,6 +10,27 @@ spec:
     name: matter-server
   interval: 1h
   values:
+    defaultPodOptions:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "iot",
+            "namespace": "kube-system",
+            "ips": [
+              "10.10.152.11/24",
+              "fd00:10:10:152::11/64"
+            ],
+            "mac": "02:0c:d8:a2:91:8f"
+          }]
+      hostUsers: false
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 0
+        runAsNonRoot: false # Must be run as root user
+        runAsUser: 0 # Must be run as root user
+        supplementalGroups:
+          - 34
     controllers:
       matter-server:
         annotations:
@@ -25,10 +46,10 @@ spec:
               - --log-level=debug
               - --log-level-sdk=info
             env:
-              MATTER_SERVER__INSTANCE_NAME: "{{ .Release.Name }}"
-              MATTER_SERVER__PORT: &port 5580
               MATTER_SERVER__APPLICATION_URL: "{{ .Release.Name }}.dcunha.io"
+              MATTER_SERVER__INSTANCE_NAME: "{{ .Release.Name }}"
               MATTER_SERVER__LOG_LEVEL: info
+              MATTER_SERVER__PORT: &port 5580
             probes:
               liveness:
                 enabled: true
@@ -51,39 +72,6 @@ spec:
             resources:
               limits:
                 memory: 350Mi
-    defaultPodOptions:
-      annotations:
-        k8s.v1.cni.cncf.io/networks: |-
-          [{
-            "name": "iot",
-            "namespace": "kube-system",
-            "ips": [
-              "10.10.152.11/24",
-              "fd00:10:10:152::11/64"
-            ],
-            "mac": "02:0c:d8:a2:91:8f"
-          }]
-      hostUsers: false
-      securityContext:
-        runAsNonRoot: false # Must be run as root user
-        runAsUser: 0 # Must be run as root user
-        runAsGroup: 0
-        fsGroup: 0
-        fsGroupChangePolicy: OnRootMismatch
-        supplementalGroups:
-          - 34
-    service:
-      app:
-        ports:
-          http:
-            port: *port
-    route:
-      app:
-        hostnames:
-          - "{{ .Release.Name }}.dcunha.io"
-        parentRefs:
-          - name: internal-gateway
-            namespace: network
     persistence:
       data:
         existingClaim: "{{ .Release.Name }}"
@@ -94,3 +82,15 @@ spec:
             app:
               - path: /tmp
                 subPath: tmp
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.dcunha.io"
+        parentRefs:
+          - name: internal-gateway
+            namespace: network
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/home-automation/matter-server/ks.yaml
+++ b/kubernetes/apps/home-automation/matter-server/ks.yaml
@@ -5,27 +5,27 @@ kind: Kustomization
 metadata:
   name: &app matter-server
 spec:
-  components:
-    - ../../../../components/volsync
   targetNamespace: home-automation
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
-    - name: multus-networks
-      namespace: kube-system
   path: ./kubernetes/apps/home-automation/matter-server/app
-  postBuild:
-    substitute:
-      APP: matter-server
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "51 * * * *"
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  wait: true
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: multus-networks
+      namespace: kube-system
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: matter-server
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SCHEDULE: "51 * * * *"

--- a/kubernetes/apps/home-automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/app/helmrelease.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -9,11 +10,35 @@ spec:
     name: mosquitto
   interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+    configMaps:
+      config:
+        data:
+          mosquitto.conf: |-
+            allow_anonymous true
+            autosave_interval 60
+            connection_messages false
+            listener 1883
+            per_listener_settings false
+            persistence true
+            persistence_location /config
     controllers:
       mosquitto:
         type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
+        statefulset:
+          volumeClaimTemplates:
+            - accessMode: ReadWriteOnce
+              name: config
+              size: 5Gi
+              storageClass: ceph-block
         pod:
         # annotations:
         #   k8s.v1.cni.cncf.io/networks: |-
@@ -27,29 +52,24 @@ spec:
             image:
               repository: public.ecr.aws/docker/library/eclipse-mosquitto
               tag: 2.0.22@sha256:914f529386804c8278a4e581526b9be5e1604df44b30daabc70aa97dcefe5268
-            env:
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 10m
               limits:
                 memory: 100Mi
-        statefulset:
-          volumeClaimTemplates:
-            - name: config
-              storageClass: ceph-block
-              accessMode: ReadWriteOnce
-              size: 5Gi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+    persistence:
+      config-file:
+        type: configMap
+        identifier: config
+        globalMounts:
+          - path: /mosquitto/config/mosquitto.conf
+            subPath: mosquitto.conf
     service:
       app:
         type: LoadBalancer
@@ -69,21 +89,3 @@ spec:
         ports:
           mqtt:
             port: 1883
-    configMaps:
-      config:
-        data:
-          mosquitto.conf: |-
-            allow_anonymous true
-            autosave_interval 60
-            connection_messages false
-            listener 1883
-            per_listener_settings false
-            persistence true
-            persistence_location /config
-    persistence:
-      config-file:
-        type: configMap
-        identifier: config
-        globalMounts:
-          - path: /mosquitto/config/mosquitto.conf
-            subPath: mosquitto.conf

--- a/kubernetes/apps/home-automation/mosquitto/ks.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/ks.yaml
@@ -9,14 +9,14 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   path: ./kubernetes/apps/home-automation/mosquitto/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  wait: true
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph


### PR DESCRIPTION
## Summary

- Fix `ks.yaml` spec field order across all three apps (`components`/`dependsOn` moved to correct positions after `sourceRef → interval → wait`)
- Move `defaultPodOptions` first in `spec.values` for all three HelmReleases
- Alphabetize remaining values keys (`controllers → persistence → route → service`), `securityContext` fields, and container field order (`resources` before `securityContext`)
- Fix mosquitto controller order: `type → annotations → statefulset → pod → containers`; remove empty `env:` field; expand inline `capabilities` to multi-line; add missing schema comment
- Fix esphome `buildcache` persistence field order and `externalsecret.yaml` spec field order; add missing `refreshInterval: 1h`
- Reorder matter-server env keys alphabetically; reorder `defaultPodOptions.securityContext` alphabetically

No functional changes — ordering and convention compliance only.