### PR TITLE
chore(home-automation): bring homebridge and mosquitto manifests to convention

### DIFF
--- a/kubernetes/apps/home-automation/homebridge/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/homebridge/app/helmrelease.yaml
@@ -10,8 +10,29 @@ spec:
     name: homebridge
   interval: 1h
   values:
+    defaultPodOptions:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "iot",
+            "namespace": "kube-system",
+            "ips": [
+              "10.10.152.12/24",
+              "fd00:10:10:152::12/64"
+            ],
+            "mac": "02:EE:BB:51:B4:DC"
+          }]
+      hostUsers: false
+      securityContext:
+        runAsNonRoot: false # Must be false - homebridge container expects root
+        runAsUser: 0 # Run as root (required by homebridge/homebridge image)
+        runAsGroup: 0 # Root group
+        fsGroup: 0 # File system group set to root
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault # Still use default seccomp profile for syscall filtering
     controllers:
-      matter-server:
+      homebridge:
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
@@ -52,39 +73,6 @@ spec:
                 memory: 100Mi
               limits:
                 memory: 750Mi
-    defaultPodOptions:
-      annotations:
-        k8s.v1.cni.cncf.io/networks: |-
-          [{
-            "name": "iot",
-            "namespace": "kube-system",
-            "ips": [
-              "10.10.152.12/24",
-              "fd00:10:10:152::12/64"
-            ],
-            "mac": "02:EE:BB:51:B4:DC"
-          }]
-      hostUsers: false
-      securityContext:
-        runAsNonRoot: false # Must be false - homebridge container expects root
-        runAsUser: 0 # Run as root (required by homebridge/homebridge image)
-        runAsGroup: 0 # Root group
-        fsGroup: 0 # File system group set to root
-        fsGroupChangePolicy: OnRootMismatch
-        seccompProfile:
-          type: RuntimeDefault # Still use default seccomp profile for syscall filtering
-    service:
-      app:
-        ports:
-          http:
-            port: *port
-    route:
-      app:
-        hostnames:
-          - "{{ .Release.Name }}.dcunha.io"
-        parentRefs:
-          - name: internal-gateway
-            namespace: network
     persistence:
       data:
         existingClaim: "{{ .Release.Name }}"
@@ -93,7 +81,19 @@ spec:
       tmp:
         type: emptyDir
         advancedMounts:
-          matter-server:
+          homebridge:
             app:
               - path: /tmp
                 subPath: tmp
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.dcunha.io"
+        parentRefs:
+          - name: internal-gateway
+            namespace: network
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/home-automation/homebridge/ks.yaml
+++ b/kubernetes/apps/home-automation/homebridge/ks.yaml
@@ -5,27 +5,27 @@ kind: Kustomization
 metadata:
   name: &app homebridge
 spec:
-  components:
-    - ../../../../components/volsync
   targetNamespace: home-automation
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
-    - name: multus-networks
-      namespace: kube-system
   path: ./kubernetes/apps/home-automation/homebridge/app
-  postBuild:
-    substitute:
-      APP: *app
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "48 * * * *"
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: multus-networks
+      namespace: kube-system
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SCHEDULE: "48 * * * *"
+  wait: true

--- a/kubernetes/apps/home-automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/app/helmrelease.yaml
@@ -52,6 +52,11 @@ spec:
             image:
               repository: public.ecr.aws/docker/library/eclipse-mosquitto
               tag: 2.0.22@sha256:914f529386804c8278a4e581526b9be5e1604df44b30daabc70aa97dcefe5268
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
             resources:
               requests:
                 cpu: 10m

--- a/kubernetes/apps/home-automation/mosquitto/ks.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/ks.yaml
@@ -16,7 +16,7 @@ spec:
     name: flux-system
     namespace: flux-system
   interval: 1h
-  wait: true
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
+  wait: true


### PR DESCRIPTION
## Summary

- **homebridge**: fix `ks.yaml` spec field ordering, promote `defaultPodOptions` to first in values, reorder remaining values keys alphabetically, rename controller from stale `matter-server` copypaste to `homebridge`
- **mosquitto**: fix `ks.yaml` spec field ordering (`dependsOn` before `wait`), restore missing `sourceRef.namespace: flux-system`, add liveness/readiness probes

## Test plan

- [ ] `just kube apply-ks home-automation home-automation-homebridge`
- [ ] `just kube apply-ks home-automation home-automation-mosquitto`