### PR TITLE
chore(home-automation): bring node-red manifests to convention

### DIFF
--- a/kubernetes/apps/home-automation/node-red/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/node-red/app/helmrelease.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -9,8 +10,17 @@ spec:
     name: node-red
   interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
       node-red:
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
@@ -44,35 +54,16 @@ spec:
                 spec:
                   failureThreshold: 30
                   periodSeconds: 10
+            resources:
+              requests:
+                cpu: 150m
+                memory: 350Mi
+              limits:
+                memory: 1Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false # Node-RED writes to /data at runtime
               capabilities: {drop: ["ALL"]}
-            resources:
-              requests:
-                memory: 350Mi
-                cpu: 150m
-              limits:
-                memory: 1Gi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
-    service:
-      app:
-        ports:
-          http:
-            port: *port
-    route:
-      app:
-        hostnames:
-          - "{{ .Release.Name }}.dcunha.io"
-        parentRefs:
-          - name: internal-gateway
-            namespace: network
     persistence:
       data:
         existingClaim: "{{ .Release.Name }}"
@@ -85,3 +76,15 @@ spec:
             app:
               - path: /tmp
                 subPath: tmp
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.dcunha.io"
+        parentRefs:
+          - name: internal-gateway
+            namespace: network
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/home-automation/node-red/ks.yaml
+++ b/kubernetes/apps/home-automation/node-red/ks.yaml
@@ -5,25 +5,25 @@ kind: Kustomization
 metadata:
   name: &app node-red
 spec:
-  components:
-    - ../../../../components/volsync
   targetNamespace: home-automation
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   path: ./kubernetes/apps/home-automation/node-red/app
-  postBuild:
-    substitute:
-      APP: node-red
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "54 * * * *"
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: node-red
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SCHEDULE: "54 * * * *"
+  wait: true


### PR DESCRIPTION
## Summary

- Add missing HelmRelease schema comment
- Promote `defaultPodOptions` to first key in `spec.values`
- Reorder values keys alphabetically: `controllers → persistence → route → service`
- Add `reloader.stakater.com/auto: "true"` annotation to the controller
- Fix container field ordering: `resources` before `securityContext`
- Fix `resources.requests` ordering: `cpu` before `memory`
- Fix `ks.yaml` spec field ordering per convention

## Test plan

- [ ] `just kube apply-ks home-automation home-automation-node-red`