### PR TITLE
chore(home-automation): bring home-assistant manifests to convention (partial)

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/externalsecret.yaml
@@ -5,6 +5,18 @@ kind: ExternalSecret
 metadata:
   name: &secretname home-assistant
 spec:
+  dataFrom:
+    - extract:
+        key: home-assistant
+    - extract:
+        key: govee
+    - extract:
+        key: leviton
+    - extract:
+        key: pirate-weather
+        # - extract:
+        #     key: google-nest
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
@@ -23,14 +35,3 @@ spec:
         HASS_LONGITUDE: "{{ .LONGITUDE }}"
         HASS_PIRATE_WEATHER_API_KEY: "{{ .PIRATE_WEATHER_API_KEY }}"
         POCKET_ID_CLIENT_SECRET: "{{ .POCKET_ID_CLIENT_SECRET }}"
-  dataFrom:
-    - extract:
-        key: home-assistant
-    - extract:
-        key: govee
-    - extract:
-        key: leviton
-    - extract:
-        key: pirate-weather
-        # - extract:
-        #     key: google-nest

--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -10,6 +10,24 @@ spec:
     name: home-assistant
   interval: 1h
   values:
+    defaultPodOptions:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "iot",
+            "namespace": "kube-system",
+            "ips": [
+              "10.10.152.10/24",
+              "fd00:10:10:152::10/64"
+            ],
+            "mac": "02:4d:60:06:55:be"
+          }]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
       home-assistant:
         annotations:
@@ -55,60 +73,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 128Mi
               limits:
                 memory: 1Gi
-    defaultPodOptions:
-      annotations:
-        k8s.v1.cni.cncf.io/networks: |-
-          [{
-            "name": "iot",
-            "namespace": "kube-system",
-            "ips": [
-              "10.10.152.10/24",
-              "fd00:10:10:152::10/64"
-            ],
-            "mac": "02:4d:60:06:55:be"
-          }]
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
-    service:
-      app:
-        ports:
-          http:
-            port: &appPort 8123
-          codeserver:
-            port: &codeserverPort 12321
-    route:
-      app:
-        annotations:
-          gatus.home-operations.com/endpoint: |-
-            conditions: ["[STATUS] == 200"]
-        hostnames:
-          - "{{ .Release.Name }}.dcunha.io"
-          - hass.dcunha.io
-        parentRefs:
-          - name: external-gateway
-            namespace: network
-          - name: internal-gateway
-            namespace: network
-        rules:
-          - backendRefs:
-              - name: "{{ .Release.Name }}"
-                port: *appPort
-      codeserver:
-        hostnames:
-          - "hass-code.dcunha.io"
-        parentRefs:
-          - name: internal-gateway
-            namespace: network
-        rules:
-          - backendRefs:
-              - name: "{{ .Release.Name }}"
-                port: *codeserverPort
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"
@@ -125,3 +92,37 @@ spec:
             app:
               - path: /tmp
                 subPath: tmp
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            conditions: ["[STATUS] == 200"]
+        hostnames:
+          - "{{ .Release.Name }}.dcunha.io"
+          - hass.dcunha.io
+        parentRefs:
+          - name: external-gateway
+            namespace: network
+          - name: internal-gateway
+            namespace: network
+        rules:
+          - backendRefs:
+              - name: "{{ .Release.Name }}"
+                port: 8123
+      codeserver:
+        hostnames:
+          - "hass-code.dcunha.io"
+        parentRefs:
+          - name: internal-gateway
+            namespace: network
+        rules:
+          - backendRefs:
+              - name: "{{ .Release.Name }}"
+                port: 12321
+    service:
+      app:
+        ports:
+          codeserver:
+            port: 12321
+          http:
+            port: 8123

--- a/kubernetes/apps/home-automation/home-assistant/ks.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/ks.yaml
@@ -5,27 +5,29 @@ kind: Kustomization
 metadata:
   name: &app home-assistant
 spec:
-  components:
-    - ../../../../components/volsync
   targetNamespace: home-automation
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
-    - name: multus-networks
-      namespace: kube-system
   path: ./kubernetes/apps/home-automation/home-assistant/app
-  postBuild:
-    substitute:
-      APP: home-assistant
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_SCHEDULE: "45 * * * *"
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: multus-networks
+      namespace: kube-system
+    - name: onepassword-connect
+      namespace: external-secrets
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: home-assistant
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_SCHEDULE: "45 * * * *"
+  wait: true


### PR DESCRIPTION
## Summary

- Fix `ks.yaml` spec field ordering and add missing `onepassword-connect` to `dependsOn`
- Promote `defaultPodOptions` to first key in `spec.values`
- Reorder values keys alphabetically: `controllers → persistence → route → service`
- Fix YAML anchor-before-alias violation by inlining port literals
- Add `memory: 128Mi` request to `codeserver` container
- Reorder `ExternalSecret` spec fields alphabetically and add `refreshInterval: 1h`

Probes (H17/H18) and codeserver securityContext (H22-H24) to follow in a separate PR.

## Test plan

- [ ] `just kube apply-ks home-automation home-automation-home-assistant`