### PR TITLE
chore(home-automation): bring zigbee manifests to convention

### DIFF
--- a/kubernetes/apps/home-automation/zigbee/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/zigbee/app/externalsecret.yaml
@@ -5,6 +5,10 @@ kind: ExternalSecret
 metadata:
   name: &secretname zigbee
 spec:
+  dataFrom:
+    - extract:
+        key: zigbee
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
@@ -14,8 +18,5 @@ spec:
       engineVersion: v2
       data:
         ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID: "{{ .ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID }}"
-        ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: "{{ .ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID }}"
         ZIGBEE2MQTT_CONFIG_ADVANCED_NETWORK_KEY: "{{ .ZIGBEE2MQTT_CONFIG_ADVANCED_NETWORK_KEY }}"
-  dataFrom:
-    - extract:
-        key: zigbee
+        ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: "{{ .ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID }}"

--- a/kubernetes/apps/home-automation/zigbee/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee/app/helmrelease.yaml
@@ -10,6 +10,13 @@ spec:
     name: zigbee
   interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
     controllers:
       zigbee:
         annotations:
@@ -20,7 +27,6 @@ spec:
               repository: ghcr.io/koenkk/zigbee2mqtt
               tag: 2.10.1@sha256:67c26dcf8346aced02fe1380a6afd1b57268bcef10faae3f6057c13d5d3dfa80
             env:
-              ZIGBEE2MQTT_DATA: /config
               ZIGBEE2MQTT_CONFIG_ADVANCED_LAST_SEEN: ISO_8601
               ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_LEVEL: info
               ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_OUTPUT: '["console"]'
@@ -29,8 +35,8 @@ spec:
               ZIGBEE2MQTT_CONFIG_DEVICE_OPTIONS_RETAIN: "true"
               ZIGBEE2MQTT_CONFIG_FRONTEND_PORT: &port 8080
               ZIGBEE2MQTT_CONFIG_FRONTEND_URL: https://zigbee.dcunha.io
-              ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED: true
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_DISCOVERY_TOPIC: homeassistant
+              ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED: true
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_STATUS_TOPIC: homeassistant/status
               ZIGBEE2MQTT_CONFIG_MQTT_INCLUDE_DEVICE_INFORMATION: "true"
               ZIGBEE2MQTT_CONFIG_MQTT_KEEPALIVE: 60
@@ -38,10 +44,11 @@ spec:
               ZIGBEE2MQTT_CONFIG_MQTT_SERVER: mqtt://mosquitto.home-automation.svc.cluster.local:1883
               ZIGBEE2MQTT_CONFIG_MQTT_VERSION: 5
               ZIGBEE2MQTT_CONFIG_PERMIT_JOIN: "false"
+              ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: zstack
               ZIGBEE2MQTT_CONFIG_SERIAL_BAUDRATE: 115200
               ZIGBEE2MQTT_CONFIG_SERIAL_DISABLE_LED: "false"
               ZIGBEE2MQTT_CONFIG_SERIAL_PORT: tcp://10.10.152.90:6638 # CHANGE TO YOUR COORDINATOR IP
-              ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: zstack
+              ZIGBEE2MQTT_DATA: /config
             envFrom:
               - secretRef:
                   name: zigbee
@@ -55,27 +62,26 @@ spec:
                 spec:
                   failureThreshold: 30
                   periodSeconds: 10
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 10m
+                memory: 128Mi
               limits:
                 memory: 1Gi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
-    service:
-      app:
-        ports:
-          http:
-            port: *port
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+              readOnlyRootFilesystem: true
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          zigbee:
+            app:
+              - path: /tmp
+                subPath: tmp
     route:
       app:
         hostnames:
@@ -83,6 +89,8 @@ spec:
         parentRefs:
           - name: internal-gateway
             namespace: network
-    persistence:
-      config:
-        existingClaim: "{{ .Release.Name }}"
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/home-automation/zigbee/ks.yaml
+++ b/kubernetes/apps/home-automation/zigbee/ks.yaml
@@ -5,25 +5,27 @@ kind: Kustomization
 metadata:
   name: &app zigbee
 spec:
-  components:
-    - ../../../../components/volsync
   targetNamespace: home-automation
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   path: ./kubernetes/apps/home-automation/zigbee/app
-  postBuild:
-    substitute:
-      APP: zigbee
-      VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_SCHEDULE: "57 * * * *"
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: zigbee
+      VOLSYNC_CAPACITY: 1Gi
+      VOLSYNC_SCHEDULE: "57 * * * *"
+  wait: true


### PR DESCRIPTION
## Summary

- Fix `ks.yaml` spec field ordering; add missing `onepassword-connect` `dependsOn`
- Move `defaultPodOptions` first in `spec.values`; reorder remaining values keys alphabetically
- Add `resources.requests.memory: 128Mi`
- Add `tmp` emptyDir with `advancedMounts` (required by `readOnlyRootFilesystem: true`)
- Sort env vars alphabetically (3 ordering violations)
- Fix `securityContext` field ordering in both pod and container contexts
- Add `refreshInterval: 1h` to ExternalSecret; reorder spec fields alphabetically

## Test plan

- [ ] `just kube apply-ks home-automation home-automation-zigbee`
- [ ] Verify zigbee HelmRelease reconciles successfully
- [ ] Verify zigbee2mqtt pod starts and connects to coordinator