### PR TITLE
chore(cortex): bring open-webui manifests to convention

### DIFF
--- a/kubernetes/apps/cortex/open-webui/app/externalsecret.yaml
+++ b/kubernetes/apps/cortex/open-webui/app/externalsecret.yaml
@@ -5,6 +5,10 @@ kind: ExternalSecret
 metadata:
   name: &secretname open-webui
 spec:
+  dataFrom:
+    - extract:
+        key: open-webui
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
@@ -14,6 +18,3 @@ spec:
       engineVersion: v2
       data:
         OAUTH_CLIENT_SECRET: "{{ .OAUTH_CLIENT_SECRET }}"
-  dataFrom:
-    - extract:
-        key: open-webui

--- a/kubernetes/apps/cortex/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/open-webui/app/helmrelease.yaml
@@ -10,6 +10,13 @@ spec:
     name: open-webui
   interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
     controllers:
       open-webui:
         annotations:
@@ -20,25 +27,25 @@ spec:
               repository: ghcr.io/open-webui/open-webui
               tag: v0.9.5 # https://github.com/open-webui/open-webui/releases
             env:
-              OLLAMA_BASE_URL: "http://ollama.dcunha.io:11434"
-              ENABLE_OLLAMA_API: "true"
-              WEBUI_URL: "https://chat.dcunha.io"
-              ENABLE_RAG_WEB_SEARCH: "true"
-              RAG_WEB_SEARCH_ENGINE: "searxng"
-              SEARXNG_QUERY_URL: "http://searxng.cortex.svc.cluster.local:8080/search?q=<query>&format=json"
-              OPENAI_API_BASE_URL: "http://pipelines.cortex.svc.cluster.local:9099"
-              OPENAI_API_KEY: "0p3n-w3bu!"
-              PORT: &port 8080
               ENABLE_OAUTH_SIGNUP: "true"
-              OAUTH_PROVIDER_NAME: "Pocket-ID"
-              OPENID_PROVIDER_URL: "https://auth.dcunha.io/.well-known/openid-configuration"
+              ENABLE_OLLAMA_API: "true"
+              ENABLE_RAG_WEB_SEARCH: "true"
+              OAUTH_ADMIN_ROLES: "admins,infra"
+              OAUTH_ALLOWED_ROLES: "admins,infra,users"
               OAUTH_CLIENT_ID: "openwebui"
+              OAUTH_EMAIL_CLAIM: "email"
+              OAUTH_PROVIDER_NAME: "Pocket-ID"
+              OAUTH_ROLES_CLAIM: "groups"
               OAUTH_SCOPES: "openid profile email"
               OAUTH_USERNAME_CLAIM: "preferred_username"
-              OAUTH_EMAIL_CLAIM: "email"
-              OAUTH_ROLES_CLAIM: "groups"
-              OAUTH_ALLOWED_ROLES: "admins,infra,users"
-              OAUTH_ADMIN_ROLES: "admins,infra"
+              OLLAMA_BASE_URL: "http://ollama.dcunha.io:11434"
+              OPENAI_API_BASE_URL: "http://pipelines.cortex.svc.cluster.local:9099"
+              OPENAI_API_KEY: "0p3n-w3bu!"
+              OPENID_PROVIDER_URL: "https://auth.dcunha.io/.well-known/openid-configuration"
+              PORT: &port 8080
+              RAG_WEB_SEARCH_ENGINE: "searxng"
+              SEARXNG_QUERY_URL: "http://searxng.cortex.svc.cluster.local:8080/search?q=<query>&format=json"
+              WEBUI_URL: "https://chat.dcunha.io"
             envFrom:
               - secretRef:
                   name: open-webui
@@ -46,19 +53,19 @@ spec:
               liveness:
                 enabled: true
                 spec:
+                  failureThreshold: 5
                   periodSeconds: 30
                   timeoutSeconds: 10
-                  failureThreshold: 5
               readiness:
                 enabled: true
                 custom: true
                 spec:
+                  failureThreshold: 5
                   httpGet:
                     path: /health
                     port: *port
                   periodSeconds: 10
                   timeoutSeconds: 5
-                  failureThreshold: 5
               startup:
                 enabled: true
                 spec:
@@ -73,15 +80,19 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               capabilities: {drop: ["ALL"]}
-    defaultPodOptions:
-      securityContext:
-        fsGroup: 1000
-        fsGroupChangePolicy: Always
-    service:
-      app:
-        ports:
-          http:
-            port: *port
+              readOnlyRootFilesystem: true
+    persistence:
+      data:
+        existingClaim: open-webui
+        globalMounts:
+          - path: /app/backend/data
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          open-webui:
+            app:
+              - path: /tmp
+                subPath: tmp
     route:
       app:
         hostnames:
@@ -91,8 +102,8 @@ spec:
             namespace: network
           - name: external-gateway
             namespace: network
-    persistence:
-      data:
-        existingClaim: open-webui
-        globalMounts:
-          - path: /app/backend/data
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/cortex/open-webui/ks.yaml
+++ b/kubernetes/apps/cortex/open-webui/ks.yaml
@@ -5,25 +5,27 @@ kind: Kustomization
 metadata:
   name: &app open-webui
 spec:
-  components:
-    - ../../../../components/volsync
   targetNamespace: cortex
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
-    - name: pipelines
-    - name: cortex-agentmemory
   path: ./kubernetes/apps/cortex/open-webui/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  wait: true
+  dependsOn:
+    - name: cortex-agentmemory
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: pipelines
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  components:
+    - ../../../../components/volsync
   postBuild:
     substitute:
       APP: *app


### PR DESCRIPTION
## Summary

- Fix `ks.yaml` spec field order; add missing `onepassword-connect` dependsOn; sort dependsOn alphabetically
- Move `defaultPodOptions` first in `spec.values`; sort remaining values keys alphabetically (`controllers → persistence → route → service`)
- Add `runAsNonRoot: true`, `runAsUser: 1000`, `runAsGroup: 1000` to pod securityContext; fix `fsGroupChangePolicy` from `Always` → `OnRootMismatch`
- Add `readOnlyRootFilesystem: true` + `tmp` emptyDir with `advancedMounts`/`subPath` per convention
- Sort env keys alphabetically; fix probe spec field ordering (`failureThreshold` first)
- Add `refreshInterval: 1h` to ExternalSecret; fix spec field ordering to alphabetical (`dataFrom → refreshInterval → secretStoreRef → target`)

## Test plan

- [ ] Pod starts successfully after merge (watch for filesystem permission errors — `readOnlyRootFilesystem: true` was added and open-webui may need additional emptyDir mounts if it writes outside `/tmp`)
- [ ] Open WebUI loads at `chat.dcunha.io`
- [ ] OIDC login via Pocket-ID works
- [ ] Pipelines integration functional