### PR TITLE
fix(cortex): bring searxng manifests to convention

### DIFF
--- a/kubernetes/apps/cortex/searxng/app/externalsecret.yaml
+++ b/kubernetes/apps/cortex/searxng/app/externalsecret.yaml
@@ -5,6 +5,10 @@ kind: ExternalSecret
 metadata:
   name: &secretname searxng
 spec:
+  dataFrom:
+    - extract:
+        key: searxng
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
@@ -14,6 +18,3 @@ spec:
       engineVersion: v2
       data:
         SEARXNG_SECRET: "{{ .SEARXNG_SECRET }}"
-  dataFrom:
-    - extract:
-        key: searxng

--- a/kubernetes/apps/cortex/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/cortex/searxng/app/helmrelease.yaml
@@ -10,6 +10,9 @@ spec:
     name: searxng
   interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
     controllers:
       searxng:
         annotations:
@@ -64,21 +67,6 @@ spec:
                   - CHOWN
                   - SETGID
                   - SETUID
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: false
-    service:
-      app:
-        ports:
-          http:
-            port: *port
-    route:
-      app:
-        hostnames:
-          - "searxng.dcunha.io"
-        parentRefs:
-          - name: internal-gateway
-            namespace: network
     persistence:
       config:
         type: configMap
@@ -97,3 +85,15 @@ spec:
             app:
               - path: /tmp
                 subPath: tmp
+    route:
+      app:
+        hostnames:
+          - "searxng.dcunha.io"
+        parentRefs:
+          - name: internal-gateway
+            namespace: network
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/cortex/searxng/ks.yaml
+++ b/kubernetes/apps/cortex/searxng/ks.yaml
@@ -15,5 +15,8 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+  wait: true


### PR DESCRIPTION
## Summary

- Move `defaultPodOptions` first in `spec.values`, then alphabetical order (`controllers → persistence → route → service`)
- Add `dependsOn: onepassword-connect` to `ks.yaml` — ExternalSecret was present but dependency not declared
- Add `refreshInterval: 1h` to `ExternalSecret`
- Fix spec field ordering in `ExternalSecret` (`dataFrom → refreshInterval → secretStoreRef → target`) and `ks.yaml` (`interval` before `wait`)

All changes are convention/ordering only — no functional impact on the running workload.

## Test plan

- [ ] Flux reconciles `searxng` kustomization cleanly after merge
- [ ] HelmRelease remains `UpgradeSucceeded`
- [ ] SearXNG accessible at `searxng.dcunha.io`