### PR TITLE
fix(default): update komga-restart to hourly and sync external-gateway after rollout

### DIFF
--- a/kubernetes/apps/default/komga/app/resources/komga-restart.yaml
+++ b/kubernetes/apps/default/komga/app/resources/komga-restart.yaml
@@ -20,6 +20,7 @@ rules:
     verbs:
       - "get"
       - "patch"
+      - "watch"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -35,13 +36,46 @@ roleRef:
   name: komga-restart
   apiGroup: rbac.authorization.k8s.io
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: komga-restart-gateway
+  namespace: network
+rules:
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    resourceNames:
+      - "external-gateway"
+    verbs:
+      - "get"
+      - "patch"
+      - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: komga-restart-gateway
+  namespace: network
+subjects:
+  - kind: ServiceAccount
+    name: komga-restart
+    namespace: default
+roleRef:
+  kind: Role
+  name: komga-restart-gateway
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: komga-restart
   namespace: default
+  labels:
+    app.kubernetes.io/name: komga
 spec:
-  schedule: "*/30 * * * *"
+  schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
@@ -55,12 +89,12 @@ spec:
             - name: restart
               image: bitnami/kubectl:latest
               command:
-                - kubectl
-                - rollout
-                - restart
-                - deployment/komga
-                - -n
-                - default
+                - sh
+                - -c
+                - |
+                  kubectl rollout restart deployment/komga -n default &&
+                  kubectl rollout status deployment/komga -n default --timeout=120s &&
+                  kubectl rollout restart deployment/external-gateway -n network
               resources:
                 requests:
                   cpu: 10m


### PR DESCRIPTION
## Summary
- Change `komga-restart` CronJob from `*/30 * * * *` to `0 * * * *` (every hour)
- Add Role + RoleBinding in `network` namespace so the job can restart `external-gateway`
- After Komga rollout completes, restart `external-gateway` to force EDS endpoint re-sync — prevents the 503 timeout caused by Envoy holding a stale pod IP after each rollout