### PR TITLE
fix(default): bring bookboss manifests to convention

### DIFF
--- a/kubernetes/apps/default/bookboss/app/externalsecret.yaml
+++ b/kubernetes/apps/default/bookboss/app/externalsecret.yaml
@@ -5,6 +5,10 @@ kind: ExternalSecret
 metadata:
   name: &secretname bookboss
 spec:
+  dataFrom:
+    - extract:
+        key: bookboss
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
@@ -16,6 +20,3 @@ spec:
         BOOKBOSS__ENCRYPTION_SECRET: "{{ .ENCRYPTION_SECRET }}"
         BOOKBOSS__METADATA__HARDCOVER_API_TOKEN: "{{ .HARDCOVER_API_TOKEN }}"
         BOOKBOSS__OIDC__CLIENT_SECRET: "{{ .BOOKBOSS__OIDC__CLIENT_SECRET }}"
-  dataFrom:
-    - extract:
-        key: bookboss

--- a/kubernetes/apps/default/bookboss/app/helmrelease.yaml
+++ b/kubernetes/apps/default/bookboss/app/helmrelease.yaml
@@ -10,6 +10,14 @@ spec:
     name: bookboss
   interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1234
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1234
+        runAsNonRoot: true
+        runAsUser: 1234
+
     controllers:
       bookboss:
         annotations:
@@ -22,14 +30,14 @@ spec:
             env:
               BOOKBOSS__DATABASE__DATABASE_URL: sqlite:///data/bookboss.db?mode=rwc
               BOOKBOSS__FRONTEND__BASE_URL: "https://books.dcunha.io"
-              RUST_LOG: debug
               BOOKBOSS__FRONTEND__LISTEN_PORT: &port 8080
-              BOOKBOSS__LIBRARY__LIBRARY_PATH: /media/book
               BOOKBOSS__IMPORT__BOOKDROP_PATH: /media/book-ingest
               BOOKBOSS__IMPORT__POLL_INTERVAL_SECS: 60
               BOOKBOSS__IMPORT__WORKER_POLL_INTERVAL_SECS: 5
-              BOOKBOSS__OIDC__DISCOVERY_URL: "https://auth.dcunha.io"
+              BOOKBOSS__LIBRARY__LIBRARY_PATH: /media/book
               BOOKBOSS__OIDC__CLIENT_ID: bookboss
+              BOOKBOSS__OIDC__DISCOVERY_URL: "https://auth.dcunha.io"
+              RUST_LOG: debug
             envFrom:
               - secretRef:
                   name: bookboss
@@ -38,24 +46,24 @@ spec:
                 enabled: true
                 custom: true
                 spec:
+                  failureThreshold: 3
                   httpGet:
                     path: /healthz
                     port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1
-                  failureThreshold: 3
               readiness:
                 enabled: true
                 custom: true
                 spec:
+                  failureThreshold: 3
                   httpGet:
                     path: /readyz
                     port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1
-                  failureThreshold: 3
             resources:
               requests:
                 cpu: 10m
@@ -64,28 +72,34 @@ spec:
                 memory: 1Gi
             securityContext:
               allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
               capabilities:
                 drop:
                   - ALL
+              readOnlyRootFilesystem: true
 
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 2000
-        runAsGroup: 2000
-        fsGroup: 2000
-        fsGroupChangePolicy: OnRootMismatch
-
-    service:
-      app:
-        ports:
-          http:
-            port: *port
-            primary: true
-          grpc:
-            port: 8081
-            appProtocol: kubernetes.io/h2c
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        advancedMounts:
+          bookboss:
+            app:
+              - path: /data
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          bookboss:
+            app:
+              - path: /tmp
+                subPath: tmp
+      media:
+        type: nfs
+        path: /mnt/atlas/media
+        server: 10.10.99.100
+        globalMounts:
+          - path: /media/book
+            subPath: books
+          - path: /media/book-ingest
+            subPath: book-ingest
 
     route:
       app:
@@ -133,26 +147,12 @@ spec:
               - name: bookboss
                 port: 8080
 
-    persistence:
-      config:
-        existingClaim: "{{ .Release.Name }}"
-        advancedMounts:
-          bookboss:
-            app:
-              - path: /data
-      tmp:
-        type: emptyDir
-        advancedMounts:
-          bookboss:
-            app:
-              - path: /tmp
-                subPath: tmp
-      media:
-        type: nfs
-        server: 10.10.99.100
-        path: /mnt/atlas/media
-        globalMounts:
-          - path: /media/book
-            subPath: books
-          - path: /media/book-ingest
-            subPath: book-ingest
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+            primary: true
+          grpc:
+            appProtocol: kubernetes.io/h2c
+            port: 8081

--- a/kubernetes/apps/default/bookboss/ks.yaml
+++ b/kubernetes/apps/default/bookboss/ks.yaml
@@ -5,24 +5,26 @@ kind: Kustomization
 metadata:
   name: &app bookboss
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/volsync
   targetNamespace: default
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   path: ./kubernetes/apps/default/bookboss/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/volsync
+  wait: true
   postBuild:
     substitute:
       APP: *app


### PR DESCRIPTION
## Summary

- Fix `ks.yaml` spec field ordering; add missing `onepassword-connect` `dependsOn`
- Fix `ExternalSecret` spec ordering; add missing `refreshInterval: 1h`
- Move `defaultPodOptions` first in `values`; sort remaining values keys alphabetically
- Fix `runAsUser`/`runAsGroup`/`fsGroup` `2000` → `1234` (matches upstream Dockerfile `useradd -g 1234 -u 1234`)
- Sort `env` keys, probe spec fields, container `securityContext`, grpc port fields, and `media` persistence fields alphabetically

## Test plan

- [ ] `just kube apply-ks default default-bookboss` reconciles cleanly
- [ ] `kubectl get helmrelease bookboss -n default` shows `Ready`
- [ ] Books UI accessible at books.dcunha.io