### PR TITLE
fix(default): revert KOMGA_DATABASE_POOL_SIZE — breaks SQLite temp tables

### DIFF
--- a/kubernetes/apps/default/komga/app/helmrelease.yaml
+++ b/kubernetes/apps/default/komga/app/helmrelease.yaml
@@ -22,7 +22,6 @@ spec:
             env:
               SERVER_PORT: &port 80
               KOMGA_CONFIGDIR: /config
-              KOMGA_DATABASE_POOL_SIZE: "4"
               KOMGA_OAUTH2_ACCOUNT_CREATION: "true"
               SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_CLIENT_ID: komga
               SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_CLIENT_NAME: Pocket-ID


### PR DESCRIPTION
Increasing the SQLite RO pool size causes 'no such table: temp_*' errors because SQLite temp tables are connection-local. Reverting to default pool size of 1.