### PR TITLE
fix(media): use liveness endpoint for autobrr readiness probe

### DIFF
--- a/kubernetes/apps/media/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autobrr/app/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
                 spec:
                   failureThreshold: 5
                   httpGet:
-                    path: /api/healthz/readiness
+                    path: /api/healthz/liveness
                     port: *port
                   periodSeconds: 10
                   timeoutSeconds: 5


### PR DESCRIPTION
The readiness probe was hitting `/api/healthz/readiness` which blocks on IRC/torrent client connection checks and consistently times out. Switched to `/api/healthz/liveness` which just confirms the process is up.