### PR TITLE
fix(default): bring immich manifests to convention

### DIFF
--- a/kubernetes/apps/default/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/helmrelease.yaml
@@ -27,14 +27,13 @@ spec:
               repository: ghcr.io/immich-app/immich-server
               tag: v2.7.5
             env:
-              TZ: America/Toronto
-              IMMICH_WORKERS_INCLUDE: api
+              DB_DATABASE_NAME: immich
               DB_HOSTNAME: immich-database-postgres.default.svc.cluster.local
               DB_USERNAME: immich
-              DB_DATABASE_NAME: immich
-              REDIS_HOSTNAME: immich-database-redis.default.svc.cluster.local
-              IMMICH_MACHINE_LEARNING_URL: http://immich-ml.default.svc.cluster.local:3003
               IMMICH_CONFIG_FILE: /config/immich.json
+              IMMICH_MACHINE_LEARNING_URL: http://immich-ml.default.svc.cluster.local:3003
+              IMMICH_WORKERS_INCLUDE: api
+              REDIS_HOSTNAME: immich-database-redis.default.svc.cluster.local
             envFrom:
               - secretRef:
                   name: immich
@@ -73,6 +72,7 @@ spec:
               capabilities:
                 drop:
                   - ALL
+              readOnlyRootFilesystem: true
 
     service:
       server:
@@ -117,3 +117,4 @@ spec:
           server:
             app:
               - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/default/immich/database/externalsecret.yaml
+++ b/kubernetes/apps/default/immich/database/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: &secretname immich
 spec:
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/default/immich/database/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/database/helmrelease.yaml
@@ -15,13 +15,6 @@ spec:
         type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 999
-            runAsGroup: 999
-            fsGroup: 999
-            fsGroupChangePolicy: OnRootMismatch
         statefulset:
           volumeClaimTemplates:
             - name: data
@@ -31,18 +24,56 @@ spec:
               globalMounts:
                 - path: /var/lib/postgresql/data
                   subPath: pgdata
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+            fsGroup: 999
+            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
               repository: ghcr.io/immich-app/postgres
               tag: 16-vectorchord0.4.3-pgvectors0.2.0
             env:
-              POSTGRES_USER: immich
-              POSTGRES_DB: immich
               PGDATA: /var/lib/postgresql/data/pgdata
+              POSTGRES_DB: immich
+              POSTGRES_USER: immich
             envFrom:
               - secretRef:
                   name: immich
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - pg_isready
+                      - -U
+                      - immich
+                      - -d
+                      - immich
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command:
+                      - pg_isready
+                      - -U
+                      - immich
+                      - -d
+                      - immich
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
             resources:
               requests:
                 cpu: 100m
@@ -66,6 +97,25 @@ spec:
             image:
               repository: docker.io/valkey/valkey
               tag: 9-alpine
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 6379
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 6379
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  failureThreshold: 3
             resources:
               requests:
                 cpu: 10m
@@ -77,6 +127,7 @@ spec:
               capabilities:
                 drop:
                   - ALL
+              readOnlyRootFilesystem: true
 
     service:
       postgres:
@@ -89,3 +140,12 @@ spec:
         ports:
           redis:
             port: 6379
+
+    persistence:
+      redis-tmp:
+        type: emptyDir
+        advancedMounts:
+          redis:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -9,17 +9,19 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: immich
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   path: ./kubernetes/apps/default/immich/database
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: onepassword-connect
+      namespace: external-secrets
+  wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -31,16 +33,16 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: immich
-  dependsOn:
-    - name: immich-database
   path: ./kubernetes/apps/default/immich/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: true
   interval: 1h
+  dependsOn:
+    - name: immich-database
+  wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -52,16 +54,16 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: immich
-  dependsOn:
-    - name: immich-app
   path: ./kubernetes/apps/default/immich/microservices
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false
   interval: 1h
+  dependsOn:
+    - name: immich-app
+  wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -73,13 +75,13 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: immich
-  dependsOn:
-    - name: immich-app
   path: ./kubernetes/apps/default/immich/machine-learning
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false
   interval: 1h
+  dependsOn:
+    - name: immich-app
+  wait: false

--- a/kubernetes/apps/default/immich/machine-learning/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/machine-learning/helmrelease.yaml
@@ -16,6 +16,7 @@ spec:
           reloader.stakater.com/auto: "true"
         pod:
           securityContext:
+            runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
             fsGroup: 1000
@@ -26,9 +27,31 @@ spec:
               repository: ghcr.io/immich-app/immich-machine-learning
               tag: v2.7.5
             env:
-              TZ: America/Toronto
               HF_HUB_DISABLE_XET: "1"
               MPLCONFIGDIR: /tmp/matplotlib
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: 3003
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: 3003
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
             resources:
               requests:
                 cpu: 100m
@@ -40,6 +63,7 @@ spec:
               capabilities:
                 drop:
                   - ALL
+              readOnlyRootFilesystem: true
 
     service:
       app:
@@ -64,3 +88,4 @@ spec:
           app:
             app:
               - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/default/immich/microservices/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/microservices/helmrelease.yaml
@@ -27,17 +27,21 @@ spec:
               repository: ghcr.io/immich-app/immich-server
               tag: v2.7.5
             env:
-              TZ: America/Toronto
-              IMMICH_WORKERS_EXCLUDE: api
+              DB_DATABASE_NAME: immich
               DB_HOSTNAME: immich-database-postgres.default.svc.cluster.local
               DB_USERNAME: immich
-              DB_DATABASE_NAME: immich
-              REDIS_HOSTNAME: immich-database-redis.default.svc.cluster.local
-              IMMICH_MACHINE_LEARNING_URL: http://immich-ml.default.svc.cluster.local:3003
               IMMICH_CONFIG_FILE: /config/immich.json
+              IMMICH_MACHINE_LEARNING_URL: http://immich-ml.default.svc.cluster.local:3003
+              IMMICH_WORKERS_EXCLUDE: api
+              REDIS_HOSTNAME: immich-database-redis.default.svc.cluster.local
             envFrom:
               - secretRef:
                   name: immich
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
             resources:
               requests:
                 cpu: 100m
@@ -49,6 +53,7 @@ spec:
               capabilities:
                 drop:
                   - ALL
+              readOnlyRootFilesystem: true
 
     persistence:
       library:
@@ -74,3 +79,4 @@ spec:
           app:
             app:
               - path: /tmp
+                subPath: tmp


### PR DESCRIPTION
## Summary

- Remove `TZ` env var from server, microservices, and ML containers (k8tz handles timezone cluster-wide)
- Add `readOnlyRootFilesystem: true` to server, redis, microservices, and ML containers; postgres excluded (custom Immich postgres image writes to `/etc/postgresql` at startup)
- Add `runAsNonRoot: true` to machine-learning pod security context (was missing)
- Add health probes: `pg_isready` exec for postgres, TCP socket for redis, HTTP `GET /ping` for ML, disabled on microservices (no HTTP port)
- Add `redis-tmp` emptyDir with `subPath: tmp`; add `subPath: tmp` to all existing tmp mounts
- Sort env vars alphabetically across all HelmReleases
- Fix `statefulset` field order in database controller (before `pod`, per convention)
- Fix `ks.yaml` spec field order on all 4 Kustomizations (`dependsOn` after `interval`)
- Add `onepassword-connect` to `immich-database` Kustomization `dependsOn`
- Add `refreshInterval: 1h` to ExternalSecret

## Test plan

- [x] All 4 HelmReleases `Ready: True` after live apply
- [x] All 5 pods `1/1 Running`
- [x] ML probe path confirmed via `python3 urllib` exec against running container (`/ping` → `pong`)
- [x] Postgres `readOnlyRootFilesystem` dropped after confirming incompatibility with startup image behavior