### PR TITLE
fix(default): bring komga manifests to convention

### DIFF
--- a/kubernetes/apps/default/komga/app/externalsecret.yaml
+++ b/kubernetes/apps/default/komga/app/externalsecret.yaml
@@ -5,6 +5,10 @@ kind: ExternalSecret
 metadata:
   name: &secretname komga
 spec:
+  dataFrom:
+    - extract:
+        key: komga
+  refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
@@ -15,6 +19,3 @@ spec:
       data:
         KOMGA_API_KEY: "{{ .KOMGA_API_KEY }}"
         SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_POCKETID_CLIENT_SECRET: "{{ .KOMGA_OIDC_CLIENT_SECRET }}"
-  dataFrom:
-    - extract:
-        key: komga

--- a/kubernetes/apps/default/komga/app/helmrelease.yaml
+++ b/kubernetes/apps/default/komga/app/helmrelease.yaml
@@ -10,6 +10,13 @@ spec:
     name: komga
   interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
     controllers:
       komga:
         annotations:
@@ -34,52 +41,34 @@ spec:
               liveness:
                 enabled: true
                 spec:
+                  failureThreshold: 5
                   periodSeconds: 30
                   timeoutSeconds: 5
-                  failureThreshold: 5
               readiness:
                 enabled: true
                 custom: true
                 spec:
+                  failureThreshold: 5
                   httpGet:
                     path: /actuator/health
                     port: *port
                   periodSeconds: 10
                   timeoutSeconds: 5
-                  failureThreshold: 5
               startup:
                 enabled: true
                 spec:
                   failureThreshold: 30
                   periodSeconds: 10
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 500m
                 memory: 1Gi
               limits:
                 memory: 4Gi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
-    service:
-      app:
-        ports:
-          http:
-            port: *port
-    route:
-      app:
-        hostnames:
-          - "{{ .Release.Name }}.dcunha.io"
-        parentRefs:
-          - name: external-gateway
-            namespace: network
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+              readOnlyRootFilesystem: true
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"
@@ -87,8 +76,8 @@ spec:
           - path: /config
       media:
         type: nfs
-        server: 10.10.99.100
         path: /mnt/atlas/media
+        server: 10.10.99.100
         globalMounts:
           - path: /media
       tmp:
@@ -98,3 +87,15 @@ spec:
             app:
               - path: /tmp
                 subPath: tmp
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.dcunha.io"
+        parentRefs:
+          - name: external-gateway
+            namespace: network
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/default/komga/app/resources/manga-watcher.yaml
+++ b/kubernetes/apps/default/komga/app/resources/manga-watcher.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: watcher
-              image: alpine:3.23
+              image: alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
               command:
                 - "/bin/sh"
                 - "-c"
@@ -70,6 +70,15 @@ spec:
                   memory: 32Mi
                 limits:
                   memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - "ALL"
+                readOnlyRootFilesystem: true
+                runAsGroup: 1000
+                runAsNonRoot: true
+                runAsUser: 1000
               volumeMounts:
                 - name: media
                   mountPath: /media

--- a/kubernetes/apps/default/komga/ks.yaml
+++ b/kubernetes/apps/default/komga/ks.yaml
@@ -17,6 +17,8 @@ spec:
     namespace: flux-system
   interval: 1h
   dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
     - name: rook-ceph-cluster
       namespace: rook-ceph
   components:


### PR DESCRIPTION
## Summary
- Add `onepassword-connect` to `dependsOn` in ks.yaml
- Fix ExternalSecret: add `refreshInterval: 1h`, reorder spec fields
- HelmRelease: move `defaultPodOptions` first, reorder values keys, add `readOnlyRootFilesystem: true`, fix probe/securityContext/persistence field ordering
- manga-watcher: SHA-pin alpine image, add container securityContext

## Test plan
- [ ] HelmRelease reconciles successfully
- [ ] Komga UI is accessible at komga.dcunha.io
- [ ] manga-watcher CronJob completes without errors