### PR TITLE
feat(default): deploy xbrowsersync

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./bookboss/ks.yaml
   - ./immich/ks.yaml
   - ./komga/ks.yaml
+  - ./xbrowsersync/ks.yaml

--- a/kubernetes/apps/default/xbrowsersync/app/configmap.yaml
+++ b/kubernetes/apps/default/xbrowsersync/app/configmap.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: xbrowsersync-settings
+  namespace: default
+data:
+  settings.json: |-
+    {
+      "log": {
+        "file": {
+          "enabled": false
+        }
+      },
+      "server": {
+        "host": "0.0.0.0"
+      }
+    }

--- a/kubernetes/apps/default/xbrowsersync/app/externalsecret.yaml
+++ b/kubernetes/apps/default/xbrowsersync/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &secretname xbrowsersync
+spec:
+  dataFrom:
+    - extract:
+        key: xbrowsersync
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *secretname
+    template:
+      engineVersion: v2
+      data:
+        MONGO_INITDB_ROOT_PASSWORD: "{{ .password }}"
+        MONGO_INITDB_ROOT_USERNAME: "{{ .username }}"
+        XBROWSERSYNC_DB_PWD: "{{ .password }}"
+        XBROWSERSYNC_DB_USER: "{{ .username }}"

--- a/kubernetes/apps/default/xbrowsersync/app/helmrelease.yaml
+++ b/kubernetes/apps/default/xbrowsersync/app/helmrelease.yaml
@@ -1,0 +1,120 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: xbrowsersync
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: xbrowsersync
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+        runAsNonRoot: true
+
+    controllers:
+      xbrowsersync:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/xbrowsersync/api
+              tag: 1.1.13@sha256:3a6d8b512be3d6a347a6784aa813d62dd9e47cb2b23b3b92c4a78f7aede2eebd
+            envFrom:
+              - secretRef:
+                  name: xbrowsersync
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+              runAsGroup: 1000
+              runAsUser: 1000
+          mongodb:
+            image:
+              repository: docker.io/mongo
+              tag: 8@sha256:d6566e93e6a913cdb622ebe34e0ae7937d50efa60e92363fb4a84404dc890415
+            envFrom:
+              - secretRef:
+                  name: xbrowsersync
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: false
+              runAsGroup: 999
+              runAsUser: 999
+
+    persistence:
+      config:
+        type: configMap
+        name: xbrowsersync-settings
+        advancedMounts:
+          xbrowsersync:
+            app:
+              - path: /usr/src/api/config/settings.json
+                subPath: settings.json
+      config-db:
+        type: emptyDir
+        advancedMounts:
+          xbrowsersync:
+            mongodb:
+              - path: /data/configdb
+      data:
+        existingClaim: xbrowsersync
+        advancedMounts:
+          xbrowsersync:
+            mongodb:
+              - path: /data/db
+      tmp-app:
+        type: emptyDir
+        advancedMounts:
+          xbrowsersync:
+            app:
+              - path: /tmp
+      tmp-mongo:
+        type: emptyDir
+        advancedMounts:
+          xbrowsersync:
+            mongodb:
+              - path: /tmp
+
+    route:
+      app:
+        hostnames:
+          - "xbs.dcunha.io"
+        parentRefs:
+          - name: internal-gateway
+            namespace: network
+
+    service:
+      app:
+        ports:
+          http:
+            port: 8080

--- a/kubernetes/apps/default/xbrowsersync/app/kustomization.yaml
+++ b/kubernetes/apps/default/xbrowsersync/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/xbrowsersync/app/ocirepository.yaml
+++ b/kubernetes/apps/default/xbrowsersync/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: xbrowsersync
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/xbrowsersync/ks.yaml
+++ b/kubernetes/apps/default/xbrowsersync/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app xbrowsersync
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/default/xbrowsersync/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  wait: true


### PR DESCRIPTION
## Summary
- Self-hosted bookmark sync API at `xbs.dcunha.io` (internal gateway)
- MongoDB sidecar in same pod, credentials via 1Password ExternalSecret
- Standalone `configmap.yaml` overrides log file (disabled) and server host (`0.0.0.0`)
- VolSync backup on 1Gi PVC for MongoDB data

## Test plan
- [x] Pod 2/2 Running
- [x] HelmRelease succeeded
- [x] MongoDB authenticated via SCRAM-SHA-256
- [x] API responding at xbs.dcunha.io
- [x] Browser extension connected and synced