### PR TITLE
feat(external-endpoints): deploy forgejo HTTPRoute at git.dcunha.io

### DIFF
--- a/kubernetes/apps/external-endpoints/services/app/forgejo/endpointslice.yaml
+++ b/kubernetes/apps/external-endpoints/services/app/forgejo/endpointslice.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: forgejo
+  labels:
+    kubernetes.io/service-name: forgejo
+addressType: IPv4
+endpoints:
+  - addresses:
+      - 10.10.99.24
+    conditions:
+      ready: true
+      serving: true
+      terminating: false
+ports:
+  - name: http
+    port: 3000
+    protocol: TCP
+    appProtocol: http

--- a/kubernetes/apps/external-endpoints/services/app/forgejo/httproute.yaml
+++ b/kubernetes/apps/external-endpoints/services/app/forgejo/httproute.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: &app forgejo
+  labels:
+    app.kubernetes.io/name: *app
+    app.kubernetes.io/instance: *app
+  annotations:
+    external-dns.alpha.kubernetes.io/internal: "true"
+spec:
+  parentRefs:
+    - name: internal-gateway
+      namespace: network
+      sectionName: https
+  hostnames:
+    - git.dcunha.io
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: *app
+          port: 3000

--- a/kubernetes/apps/external-endpoints/services/app/forgejo/kustomization.yaml
+++ b/kubernetes/apps/external-endpoints/services/app/forgejo/kustomization.yaml
@@ -3,7 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./forgejo
-  - ./proxmox
-  - ./truenas
-  - ./unifi
+  - ./service.yaml
+  - ./endpointslice.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/external-endpoints/services/app/forgejo/service.yaml
+++ b/kubernetes/apps/external-endpoints/services/app/forgejo/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: &app forgejo
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+      appProtocol: http


### PR DESCRIPTION
## Summary
- Adds Service, EndpointSlice, and HTTPRoute for Forgejo LXC at `10.10.99.24:3000`
- Exposes `git.dcunha.io` via `internal-gateway` with HTTPS termination at the cluster edge
- Forgejo v15.0.2 deployed on Debian 12 LXC (VMID 105) on pantheon

## Test plan
- [x] `https://git.dcunha.io` loads and redirects to Forgejo login
- [x] HTTPRoute accepted and refs resolved on `internal-gateway`