### PR TITLE
chore(kube-system): align cilium and coredns manifests to yaml conventions

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/grafanadashboard.yaml
@@ -6,12 +6,12 @@ metadata:
   name: cilium
 spec:
   allowCrossNamespaceImport: true
-  instanceSelector:
-    matchLabels:
-      dashboards: grafana
+  configMapRef:
+    key: cilium-dashboard.json
+    name: cilium-dashboard
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
-  configMapRef:
-    name: cilium-dashboard
-    key: cilium-dashboard.json
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -14,21 +14,21 @@ spec:
     bandwidthManager:
       enabled: true
       bbr: true
+    bgpControlPlane:
+      enabled: true
     bpf:
       datapathMode: netkit
       masquerade: true
       preallocateMaps: true
       tproxy: true
     bpfClockProbe: true
-    bgpControlPlane:
-      enabled: true
     cgroup:
       autoMount:
         enabled: false
       hostRoot: /sys/fs/cgroup
     cluster:
-      name: artemis-cluster
       id: 1
+      name: artemis-cluster
     cni:
       exclusive: false
     dashboards:
@@ -59,15 +59,15 @@ spec:
     operator:
       dashboards:
         enabled: false
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
       prometheus:
         enabled: true
         serviceMonitor:
           enabled: true
       replicas: 2
       rollOutPods: false
-      podDisruptionBudget:
-        enabled: true
-        maxUnavailable: 1
     pmtuDiscovery:
       enabled: true
     prometheus:

--- a/kubernetes/apps/kube-system/cilium/app/network.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/network.yaml
@@ -48,18 +48,18 @@ kind: CiliumBGPClusterConfig
 metadata:
   name: l3-bgp-cluster-config
 spec:
+  bgpInstances:
+    - localASN: 64512
+      name: cilium
+      peers:
+        - name: mikrotik
+          peerAddress: 10.10.99.1
+          peerASN: 64533
+          peerConfigRef:
+            name: l3-bgp-peer-config
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
-  bgpInstances:
-    - name: cilium
-      localASN: 64512
-      peers:
-        - name: mikrotik
-          peerASN: 64533
-          peerAddress: 10.10.99.1
-          peerConfigRef:
-            name: l3-bgp-peer-config
 ---
 apiVersion: v1
 kind: Service
@@ -68,7 +68,7 @@ metadata:
   namespace: kube-system
   annotations:
     lbipam.cilium.io/ips: 10.10.99.99
-    # external-dns.alpha.kubernetes.io/hostname: artemis.dcunha.io # Let Techitium manage it completly.
+    # external-dns.alpha.kubernetes.io/hostname: artemis.dcunha.io
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -9,11 +9,11 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *name
-  interval: 30m
   path: ./kubernetes/apps/kube-system/cilium/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  interval: 30m
   wait: true

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -10,18 +10,27 @@ spec:
     name: coredns
   interval: 1h
   values:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
     fullnameOverride: coredns
     image:
       repository: mirror.gcr.io/coredns/coredns
-    replicaCount: 3
+    k8sAppLabelOverride: kube-dns
     podDisruptionBudget:
       minAvailable: 2
-    k8sAppLabelOverride: kube-dns
-    serviceAccount:
-      create: true
-    service:
-      name: kube-dns
-      clusterIP: 10.43.0.10
+    prometheus:
+      monitor:
+        enabled: false
+      service:
+        enabled: false
+    prometheusRules:
+      enabled: false
+    replicaCount: 3
     servers:
       - zones:
           - zone: .
@@ -55,20 +64,11 @@ spec:
           - name: log
             configBlock: |-
               class error
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: node-role.kubernetes.io/control-plane
-                  operator: Exists
-    prometheus:
-      service:
-        enabled: false
-      monitor:
-        enabled: false
-    prometheusRules:
-      enabled: false
+    service:
+      clusterIP: 10.43.0.10
+      name: kube-dns
+    serviceAccount:
+      create: true
     tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -15,5 +15,5 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false
   interval: 30m
+  wait: false


### PR DESCRIPTION
## Summary
- Fix field ordering in `cilium` and `coredns` ks.yaml files (`path → prune → sourceRef → interval`)
- Reorder Cilium helmrelease values alphabetically (`bgpControlPlane` before `bpf`, `cluster.id/name`, `operator.podDisruptionBudget` before `prometheus`)
- Reorder CoreDNS helmrelease values alphabetically; fix `service.clusterIP/name` and `prometheus.monitor/service` ordering
- Fix `CiliumBGPClusterConfig` spec and BGP peer field ordering in `network.yaml`
- Fix `GrafanaDashboard` spec field ordering (`configMapRef → datasources → instanceSelector`)
- Remove stale Technitium comment from `network.yaml`

No functional changes — purely cosmetic YAML convention alignment.