### PR TITLE
feat(forgejo): deploy forgejo-runner, forgesync, and CI workflows

### DIFF
--- a/.forgejo/labeler.yaml
+++ b/.forgejo/labeler.yaml
@@ -1,0 +1,33 @@
+---
+area/bootstrap:
+  - changed-files:
+      - any-glob-to-any-file:
+          - bootstrap/**/*
+area/ci:
+  - changed-files:
+      - any-glob-to-any-file: ".forgejo/**/*"
+area/flux:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/flux/**/*
+area/kubernetes:
+  - changed-files:
+      - any-glob-to-any-file: "kubernetes/**/*"
+area/media:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/media/**/*
+area/observability:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/observability/**/*
+area/renovate:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .renovate/**/*
+          - renovate.json
+          - renovate.json5
+area/talos:
+  - changed-files:
+      - any-glob-to-any-file:
+          - talos/**/*

--- a/.forgejo/workflows/flux-local.yaml
+++ b/.forgejo/workflows/flux-local.yaml
@@ -1,0 +1,127 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Flux Local
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ forgejo.workflow }}-${{ forgejo.event.number || forgejo.ref }}
+  cancel-in-progress: true
+
+jobs:
+  filter:
+    name: Flux Local - Filter
+    runs-on: ubuntu-latest
+    outputs:
+      changed-files: ${{ steps.changed-files.outputs.changed_files }}
+    steps:
+      - name: Get Changed Files
+        id: changed-files
+        uses: https://github.com/bjw-s-labs/action-changed-files@a9a36fb08ce06db9b02fbd8026cc2c0945eb9841 # v0.6.0
+        with:
+          patterns: kubernetes/**/*
+
+  test:
+    if: ${{ needs.filter.outputs.changed-files != '[]' }}
+    needs: filter
+    name: Flux Local - Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run flux-local test
+        shell: bash
+        run: |-
+          flux-local test --enable-helm --all-namespaces --sources "flux-system=." --path kubernetes/flux/sync -v
+
+  diff:
+    if: ${{ needs.filter.outputs.changed-files != '[]' }}
+    needs: filter
+    name: Flux Local - Diff ${{ matrix.resources }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        resources:
+          - helmrelease
+          - kustomization
+      max-parallel: 4
+      fail-fast: false
+    steps:
+      - name: Checkout Pull Request Branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: pull
+          persist-credentials: false
+
+      - name: Checkout Default Branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: default
+          persist-credentials: false
+          ref: ${{ forgejo.event.repository.default_branch }}
+
+      - name: Run flux-local diff
+        shell: bash
+        working-directory: pull
+        run: |-
+          flux-local diff ${{ matrix.resources }} \
+            --unified 6 \
+            --sources "flux-system=." \
+            --path kubernetes/flux/sync \
+            --path-orig ../default/kubernetes/flux/sync \
+            --strip-attrs "helm.sh/chart,checksum/config,app.kubernetes.io/version,chart" \
+            --limit-bytes 10000 \
+            --all-namespaces \
+            --output-file diff.patch
+
+      - name: Generate Diff
+        id: diff
+        run: |
+          {
+              echo 'diff<<EOF'
+              cat pull/diff.patch
+              echo EOF
+          } >> "${FORGEJO_OUTPUT}";
+          {
+              echo "## Flux ${{ matrix.resources }} diff"
+              echo '```diff'
+              cat pull/diff.patch
+              echo '```'
+          } >> "${FORGEJO_STEP_SUMMARY}"
+
+      - name: Add Comment
+        if: ${{ steps.diff.outputs.diff != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+          PR_NUMBER: ${{ forgejo.event.pull_request.number }}
+          HEADER: "${{ forgejo.event.pull_request.number }}/kubernetes/${{ matrix.resources }}"
+          DIFF_CONTENT: ${{ steps.diff.outputs.diff }}
+        run: |-
+          MARKER="<!-- sticky-comment: ${HEADER} -->"
+          BODY=$(printf $'%s\n```diff\n%s\n```' "${MARKER}" "${DIFF_CONTENT}")
+          BODY_JSON=$(jq -Rs '{"body": .}' <<< "${BODY}")
+
+          COMMENT_ID=$(curl -s \
+            -H "Authorization: token ${GH_TOKEN}" \
+            "${{ forgejo.api_url }}/repos/${{ forgejo.repository }}/issues/${PR_NUMBER}/comments" \
+            | jq -r --arg marker "${MARKER}" '.[] | select(.body | startswith($marker)) | .id' | head -1)
+
+          if [[ -n "${COMMENT_ID}" ]]; then
+            curl -s -X PATCH \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Content-Type: application/json" \
+              "${{ forgejo.api_url }}/repos/${{ forgejo.repository }}/issues/comments/${COMMENT_ID}" \
+              -d "${BODY_JSON}"
+          else
+            curl -s -X POST \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Content-Type: application/json" \
+              "${{ forgejo.api_url }}/repos/${{ forgejo.repository }}/issues/${PR_NUMBER}/comments" \
+              -d "${BODY_JSON}"
+          fi

--- a/.forgejo/workflows/flux-oci-push.yaml
+++ b/.forgejo/workflows/flux-oci-push.yaml
@@ -1,0 +1,65 @@
+---
+name: Push OCI Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - kubernetes/**
+      - .sourceignore
+  workflow_dispatch:
+
+concurrency:
+  group: oci-push-${{ forgejo.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUX_VERSION: 2.8.3
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    outputs:
+      digest-url: ${{ steps.push.outputs.digest-url }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Flux CLI
+        run: |
+          curl -sLO https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz
+          tar xzf flux_${FLUX_VERSION}_linux_amd64.tar.gz
+          mv flux /usr/local/bin/
+
+      - name: Push to Forgejo
+        id: push
+        run: |
+          DIGEST_URL=$(flux push artifact \
+            oci://git.dcunha.io/exikle/artemis-cluster:${{ forgejo.sha }} \
+            --path=. \
+            --source=${{ forgejo.server_url }}/${{ forgejo.repository }} \
+            --revision=${{ forgejo.ref_name }}@sha1:${{ forgejo.sha }} \
+            --creds=exikle:${{ secrets.CI_TOKEN }} \
+            --output json | \
+            jq -r '.repository + "@" + .digest')
+          echo "digest-url=$DIGEST_URL" >> "$FORGEJO_OUTPUT"
+
+      - name: Tag main
+        run: |
+          flux tag artifact oci://git.dcunha.io/exikle/artemis-cluster:${{ forgejo.sha }} \
+            --tag main \
+            --creds=exikle:${{ secrets.CI_TOKEN }}
+
+      - name: Trigger Flux reconciliation
+        if: ${{ secrets.FLUX_WEBHOOK_URL != '' }}
+        env:
+          WEBHOOK_TOKEN: ${{ secrets.FLUX_WEBHOOK_TOKEN }}
+          WEBHOOK_URL: ${{ secrets.FLUX_WEBHOOK_URL }}
+        run: |-
+          SIGNATURE=$(printf '{}' | openssl dgst -sha256 -r -hmac "${WEBHOOK_TOKEN}" | awk '{print $1}')
+          HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST "${WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -H "X-Signature: sha256=${SIGNATURE}" \
+            -d '{}')
+          echo "Flux webhook response: HTTP ${HTTP_STATUS}"
+          test "${HTTP_STATUS}" = "200"

--- a/.forgejo/workflows/labeler.yaml
+++ b/.forgejo/workflows/labeler.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Labeler
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  labeler:
+    name: Labeler
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Labeler
+        uses: https://github.com/actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          configuration-path: .forgejo/labeler.yaml

--- a/kubernetes/apps/forgejo/forgejo-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/forgejo/forgejo-runner/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forgejo-runner
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: forgejo-runner-secret
+    creationPolicy: Owner
+    template:
+      data:
+        token: "{{ .FORGEJO_RUNNER_TOKEN }}"
+        uuid: "{{ .FORGEJO_RUNNER_UUID }}"
+  dataFrom:
+    - extract:
+        key: forgejo

--- a/kubernetes/apps/forgejo/forgejo-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/forgejo/forgejo-runner/app/helmrelease.yaml
@@ -1,0 +1,248 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo-runner
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: forgejo-runner
+  interval: 30m
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
+
+    configMaps:
+      config:
+        suffix: config
+        data:
+          runner.yaml: |-
+            cache:
+              enabled: true
+              dir: /data/cache
+            container:
+              docker_host: "-"
+              workdir_parent: shared/workdir
+            host:
+              workdir_parent: /data/act
+            kubernetes:
+              namespace: forgejo
+              poll_timeout: 10m
+            log:
+              level: info
+            plugins:
+              k8s:
+                address: "unix:///plugin/forgejo-runner-k8s.sock"
+                options:
+                  namespace: forgejo
+                  poll_timeout: 10m
+            runner:
+              capacity: 4
+              labels:
+                - ubuntu-latest:k8s:/config/podspec-default.yaml
+                - default:k8s:/config/podspec-default.yaml
+                - docker:k8s:/config/podspec-dind.yaml
+                - multiarch:k8s:/config/podspec-dind.yaml
+              timeout: 3h
+          podspec-default.yaml: |-
+            containers:
+              - env:
+                  - name: DEBIAN_FRONTEND
+                    value: noninteractive
+                image: ghcr.io/bjw-s-labs/forgejo-runner:ubuntu-24.04@sha256:4288050ddd71ac2e5f42465c474aec8b838792dec85bb284405db7c180138580
+                imagePullPolicy: IfNotPresent
+                name: main
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 2Gi
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+            restartPolicy: Never
+          podspec-dind.yaml: |-
+            initContainers:
+              - name: dind
+                image: docker:29-dind
+                securityContext:
+                  privileged: true
+                restartPolicy: Always
+                env:
+                  - name: DOCKER_TLS_CERTDIR
+                    value: /certs
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+                  limits:
+                    cpu: 500m
+                    memory: 4Gi
+                volumeMounts:
+                  - name: docker-storage
+                    mountPath: /var/lib/docker
+                  - name: docker-certs
+                    mountPath: /certs
+                readinessProbe:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - test -f /certs/client/ca.pem && test -f /certs/client/cert.pem && test -f /certs/client/key.pem
+                  initialDelaySeconds: 2
+                  periodSeconds: 1
+            containers:
+              - env:
+                  - name: DEBIAN_FRONTEND
+                    value: noninteractive
+                  - name: DOCKER_HOST
+                    value: tcp://localhost:2376
+                  - name: DOCKER_TLS_VERIFY
+                    value: "1"
+                  - name: DOCKER_CERT_PATH
+                    value: /certs/client
+                image: ghcr.io/bjw-s-labs/forgejo-runner:ubuntu-24.04@sha256:4288050ddd71ac2e5f42465c474aec8b838792dec85bb284405db7c180138580
+                imagePullPolicy: IfNotPresent
+                name: main
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 2Gi
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+                volumeMounts:
+                  - name: docker-certs
+                    mountPath: /certs
+                    readOnly: true
+            volumes:
+              - name: docker-storage
+                emptyDir: {}
+              - name: docker-certs
+                emptyDir: {}
+            restartPolicy: Never
+
+    controllers:
+      forgejo-runner:
+        type: deployment
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          labels:
+            app.kubernetes.io/component: forgejo-runner
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+        containers:
+          runner:
+            # TODO: replace with ghcr.io/exikle/runner once built in containers repo
+            image:
+              repository: git.erwanleboucher.dev/eleboucher/runner
+              tag: sha-63d5504927ba6b9d511c0972beaf4ff5b3705f82
+            command:
+              - sh
+              - -ec
+              - |
+                exec /bin/forgejo-runner daemon \
+                  --config /config/runner.yaml \
+                  --url "https://git.dcunha.io" \
+                  --uuid "$(cat /etc/forgejo-runner-secret/uuid)" \
+                  --token-url file:///etc/forgejo-runner-secret/token
+            resources:
+              requests:
+                cpu: 5m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+          k8s-plugin:
+            # TODO: replace with ghcr.io/exikle/runner-k8s-plugin once built in containers repo
+            image:
+              repository: git.erwanleboucher.dev/eleboucher/runner-k8s-plugin
+              tag: sha-f7ab06b75887e5497c9f9f9bef641aafb2ae3e1c
+            args:
+              - --listen
+              - unix:///plugin/forgejo-runner-k8s.sock
+            resources:
+              requests:
+                cpu: 5m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+
+    rbac:
+      roles:
+        forgejo-runner:
+          type: Role
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - list
+                - watch
+                - create
+                - get
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - pods/exec
+              verbs:
+                - create
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - pods/log
+              verbs:
+                - list
+                - watch
+                - get
+      bindings:
+        forgejo-runner:
+          type: RoleBinding
+          roleRef:
+            identifier: forgejo-runner
+          subjects:
+            - identifier: forgejo-runner
+
+    persistence:
+      config:
+        type: configMap
+        identifier: config
+        globalMounts:
+          - path: /config
+      runner-secret:
+        type: secret
+        name: forgejo-runner-secret
+        globalMounts:
+          - path: /etc/forgejo-runner-secret
+            readOnly: true
+      plugins:
+        type: emptyDir
+        globalMounts:
+          - path: /plugin
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /data
+            subPath: data
+          - path: /tmp
+            subPath: tmp

--- a/kubernetes/apps/forgejo/forgejo-runner/app/kustomization.yaml
+++ b/kubernetes/apps/forgejo/forgejo-runner/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/forgejo/forgejo-runner/app/ocirepository.yaml
+++ b/kubernetes/apps/forgejo/forgejo-runner/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: forgejo-runner
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/forgejo/forgejo-runner/ks.yaml
+++ b/kubernetes/apps/forgejo/forgejo-runner/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app forgejo-runner
+spec:
+  targetNamespace: forgejo
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/forgejo/forgejo-runner/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  wait: false
+

--- a/kubernetes/apps/forgejo/forgesync/app/externalsecret.yaml
+++ b/kubernetes/apps/forgejo/forgesync/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forgesync
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: forgesync-secret
+    creationPolicy: Owner
+    template:
+      data:
+        FORGESYNC_SOURCE_TOKEN: "{{ .FORGE_SYNC_SOURCE_TOKEN }}"
+        FORGESYNC_GITHUB_TOKEN: "{{ .GITHUB_PAT }}"
+  dataFrom:
+    - extract:
+        key: forgejo
+    - extract:
+        key: github

--- a/kubernetes/apps/forgejo/forgesync/app/helmrelease.yaml
+++ b/kubernetes/apps/forgejo/forgesync/app/helmrelease.yaml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgesync
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: forgesync
+  interval: 30m
+  values:
+    controllers:
+      forgesync:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+        containers:
+          app:
+            # TODO: replace with ghcr.io/exikle/forgesync once available
+            image:
+              repository: git.erwanleboucher.dev/eleboucher/forgesync
+              tag: 0.0.1
+            args:
+              - run
+            env:
+              FORGESYNC_SOURCE_URL: http://forgejo.external-endpoints.svc.cluster.local:3000
+              FORGESYNC_BOT_USERNAME: duskbot
+              FORGESYNC_LOG_FORMAT: json
+            envFrom:
+              - secretRef:
+                  name: forgesync-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 30
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 5m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL

--- a/kubernetes/apps/forgejo/forgesync/app/kustomization.yaml
+++ b/kubernetes/apps/forgejo/forgesync/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/forgejo/forgesync/app/ocirepository.yaml
+++ b/kubernetes/apps/forgejo/forgesync/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: forgesync
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/forgejo/forgesync/ks.yaml
+++ b/kubernetes/apps/forgejo/forgesync/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app forgesync
+spec:
+  targetNamespace: forgejo
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/forgejo/forgesync/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: forgejo-runner
+  wait: false

--- a/kubernetes/apps/forgejo/kustomization.yaml
+++ b/kubernetes/apps/forgejo/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: forgejo
+
+components:
+  - ../../components/alerts
+
+resources:
+  - ./namespace.yaml
+  - ./forgejo-runner/ks.yaml
+  - ./forgesync/ks.yaml

--- a/kubernetes/apps/forgejo/namespace.yaml
+++ b/kubernetes/apps/forgejo/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: forgejo
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary

- Deploys a k8s-backed Forgejo Actions runner using Erwan's custom runner image with k8s-plugin support; runner registered as `artemis-k8s` on git.dcunha.io
- Deploys forgesync for bidirectional repo mirroring between Forgejo and GitHub, running as `duskbot`
- Adds `.forgejo/` CI workflows (labeler, flux-local validation, OCI push) — dormant until Artemis-Cluster repo moves to Forgejo as primary

## Test plan

- [x] `forgejo-runner` pod running 2/2, HelmRelease healthy
- [x] `forgesync` pod running 1/1, HelmRelease healthy, bidirectional sync confirmed on `exikle/containers`
- [x] Both ExternalSecrets synced from 1Password
- [x] Runner picked up and executed jobs from containers repo