### PR TITLE
fix(forgejo): allow privileged pods for DinD runner builds

### DIFF
--- a/kubernetes/apps/forgejo/namespace.yaml
+++ b/kubernetes/apps/forgejo/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: forgejo
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
## Summary
- Adds `pod-security.kubernetes.io/enforce: privileged` label to the `forgejo` namespace
- The cluster default PodSecurity policy (`baseline:latest`) blocks `privileged: true` containers, silently causing the DinD init container in the `docker` runner label podspec to fail with exit code 1 at 0s

## Test plan
- [ ] Forgejo Actions build for `exikle/containers` completes successfully with the `docker` runner (DinD)