### PR TITLE
fix(forgejo): switch forgesync bot user from duskbot to exikle

### DIFF
--- a/kubernetes/apps/forgejo/forgesync/app/externalsecret.yaml
+++ b/kubernetes/apps/forgejo/forgesync/app/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
     creationPolicy: Owner
     template:
       data:
-        FORGESYNC_SOURCE_TOKEN: "{{ .FORGE_SYNC_SOURCE_TOKEN }}"
+        FORGESYNC_SOURCE_TOKEN: "{{ .FORGEJO_PAT }}"
         FORGESYNC_GITHUB_TOKEN: "{{ .GITHUB_PAT }}"
   dataFrom:
     - extract:

--- a/kubernetes/apps/forgejo/forgesync/app/helmrelease.yaml
+++ b/kubernetes/apps/forgejo/forgesync/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
               - run
             env:
               FORGESYNC_SOURCE_URL: http://forgejo.external-endpoints.svc.cluster.local:3000
-              FORGESYNC_BOT_USERNAME: duskbot
+              FORGESYNC_BOT_USERNAME: exikle
               FORGESYNC_LOG_FORMAT: json
             envFrom:
               - secretRef:


### PR DESCRIPTION
## Summary
- Switch `FORGESYNC_BOT_USERNAME` from `duskbot` to `exikle` (duskbot account deleted)
- Update ExternalSecret to use `FORGEJO_PAT` (exikle's token) instead of `FORGE_SYNC_SOURCE_TOKEN` (duskbot's token)